### PR TITLE
FF-1042

### DIFF
--- a/.chalice/deployed.json
+++ b/.chalice/deployed.json
@@ -49,7 +49,7 @@
     },
     "backend": "api",
     "chalice_version": "1.0.4",
-    "rest_api_id": "m1kj6dypu3",
+    "rest_api_id": "kpqxwgx646",
     "api_gateway_stage": "api",
     "region": "us-east-1"
   }

--- a/app.py
+++ b/app.py
@@ -11,25 +11,19 @@ app.debug = True
 
 ######### SCHEDULED FXNS #########
 
-# run at 10 am UTC every day
-@app.schedule(Cron(0, 10, '*', '*', '?', '*'))
-def daily_checks(event):
+
+# run every 10 mins
+@app.schedule(Rate(10, unit=Rate.MINUTES))
+def ten_min_checks(event):
     for environ in list_environments():
-        queue_check_group(environ, 'daily_checks')
+        queue_check_group(environ, 'ten_min_checks')
 
 
-# run every 6 hrs
-@app.schedule(Rate(6, unit=Rate.HOURS))
-def six_hour_checks(event):
+# run every 30 mins
+@app.schedule(Rate(30, unit=Rate.MINUTES))
+def thirty_min_checks(event):
     for environ in list_environments():
-        queue_check_group(environ, 'six_hour_checks')
-
-
-# run every 2 hrs
-@app.schedule(Rate(2, unit=Rate.HOURS))
-def two_hour_checks(event):
-    for environ in list_environments():
-        queue_check_group(environ, 'two_hour_checks')
+        queue_check_group(environ, 'thirty_min_checks')
 
 ######### END SCHEDULED FXNS #########
 

--- a/chalicelib/app_utils.py
+++ b/chalicelib/app_utils.py
@@ -10,7 +10,7 @@ from dateutil import tz
 from base64 import b64decode
 from .fs_connection import FSConnection
 from .check_utils import (
-    get_check_group_latest,
+    get_check_group_results,
     run_check_or_action,
     get_check_strings,
     fetch_check_group,
@@ -246,7 +246,7 @@ def view_foursight(environ, is_admin=False, domain=""):
     for this_environ in view_envs:
         connection, error_res = init_connection(this_environ)
         if connection:
-            results = get_check_group_latest(connection, 'all_checks')
+            results = get_check_group_results(connection, 'all_checks')
             processed_results = []
             for res in results:
                 # first check to see if res is just a string, meaning
@@ -347,7 +347,7 @@ def get_foursight_checks(environ, check_group):
     connection, response = init_response(environ)
     if not connection:
         return response
-    results = get_check_group_latest(connection, check_group)
+    results = get_check_group_results(connection, check_group)
     response.body = {
         'status': 'success',
         'environment': environ,
@@ -366,7 +366,7 @@ def get_check(environ, check):
     if not connection:
         return response
     tempCheck = init_check_res(connection, check)
-    latest_res = tempCheck.get_latest_result()
+    latest_res = tempCheck.get_primary_result()
     if latest_res:
         response.body = {
             'status': 'success',

--- a/chalicelib/app_utils.py
+++ b/chalicelib/app_utils.py
@@ -429,6 +429,8 @@ def run_put_check(environ, check, put_data):
                 setattr(putCheck, field, prev_content)
             else:
                 setattr(putCheck, field, put_content)
+    # set 'primary' kwarg so that the result is stored as 'latest'
+    putCheck.kwargs = {'primary': True}
     stored = putCheck.store_result()
     response.body = {
         'status': 'success',

--- a/chalicelib/app_utils.py
+++ b/chalicelib/app_utils.py
@@ -199,7 +199,7 @@ def view_run_check(environ, check):
 
     This also be used to run a check group. This is checked before individual check names
     """
-    if check in CHECK_GROUPS or check == 'all':
+    if check in CHECK_GROUPS:
         queue_check_group(environ, check)
     else:
         connection, _ = init_connection(environ)
@@ -246,7 +246,7 @@ def view_foursight(environ, is_admin=False, domain=""):
     for this_environ in view_envs:
         connection, error_res = init_connection(this_environ)
         if connection:
-            results = get_check_group_latest(connection, 'all')
+            results = get_check_group_latest(connection, 'all_checks')
             processed_results = []
             for res in results:
                 # first check to see if res is just a string, meaning
@@ -341,9 +341,8 @@ def run_foursight_checks(environ, check_group):
 def get_foursight_checks(environ, check_group):
     """
     Return JSON of each check tagged with the "latest" tag for checks
-    within given check_group for the given environment. If check_group == 'all', every
-    registered check will be returned. Otherwise, must be a valid check_group
-    name.
+    within given check_group for the given environment.
+    Must be a valid check_group name.
     """
     connection, response = init_response(environ)
     if not connection:
@@ -474,7 +473,7 @@ def run_put_environment(environ, env_data):
             )
         else:
             # run some checks on the new env
-            queue_check_group(environ, 'all')
+            queue_check_group(environ, 'all_checks')
             response = Response(
                 body = {
                     'status': 'success',

--- a/chalicelib/check_groups.py
+++ b/chalicelib/check_groups.py
@@ -14,24 +14,20 @@ CHECK_MODULES = [
 # define check_groups within this dict
 
 CHECK_GROUPS = {
-    'daily_checks': [
-        ['wrangler_checks/items_created_in_the_past_day', {'primary': True}, [], 'd1'],
-        ['wrangler_checks/files_associated_with_replicates', {'primary': True}, [],'d2'],
-        ['wrangler_checks/replicate_file_reporting', {'primary': True}, [], 'd3']
+    'ten_min_checks': [
+        ['system_checks/elastic_beanstalk_health', {'primary': True}, [], 'm10_1'],
+        ['wrangler_checks/items_created_in_the_past_day', {'primary': True}, [], 'm10_2'],
+        ['wrangler_checks/item_counts_by_type', {'primary': True}, [], 'm10_3'],
+        ['wrangler_checks/change_in_item_counts', {'primary': True}, ['m10_3'], 'm10_4'],
+        ['wrangler_checks/replicate_file_reporting', {'primary': True}, [], 'm10_5'],
+        ['system_checks/indexing_progress', {'primary': True}, [], 'm10_6'],
+        ['system_checks/staging_deployment', {'primary': True}, [], 'm10_7']
     ],
-    'six_hour_checks': [
-        ['system_checks/elastic_beanstalk_health', {'primary': True}, [], 's1'],
-        ['system_checks/status_of_elasticsearch_indices', {'primary': True}, [], 's2'],
-        ['system_checks/indexing_records', {'primary': True}, [], 's3'],
-        ['wrangler_checks/item_counts_by_type', {'primary': True}, [], 's4'],
-        ['wrangler_checks/change_in_item_counts', {'primary': True}, ['s4'], 's5'],
-        ['system_checks/indexing_progress', {'primary': True}, [], 's6']
-    ],
-    'two_hour_checks': [
-        ['wrangler_checks/identify_files_without_filesize', {'primary': True}, [], 't1'],
-        ['wrangler_checks/item_counts_by_type', {'primary': True}, [], 't2'],
-        ['system_checks/indexing_progress', {'primary': True}, [], 't3'],
-        ['system_checks/staging_deployment', {'primary': True}, [], 't4']
+    'thirty_min_checks': [
+        ['wrangler_checks/files_associated_with_replicates', {'primary': True}, [],'m30_1'],
+        ['system_checks/status_of_elasticsearch_indices', {'primary': True}, [], 'm30_2'],
+        ['wrangler_checks/identify_files_without_filesize', {'primary': True}, [], 'm30_3'],
+        ['system_checks/indexing_records', {'primary': True}, [], 'm30_4']
     ]
 }
 

--- a/chalicelib/check_groups.py
+++ b/chalicelib/check_groups.py
@@ -15,23 +15,23 @@ CHECK_MODULES = [
 
 CHECK_GROUPS = {
     'daily_checks': [
-        ['wrangler_checks/items_created_in_the_past_day', {}, [], 'd1'],
-        ['wrangler_checks/files_associated_with_replicates', {}, [],'d2'],
-        ['wrangler_checks/replicate_file_reporting', {}, [], 'd3']
+        ['wrangler_checks/items_created_in_the_past_day', {'primary': True}, [], 'd1'],
+        ['wrangler_checks/files_associated_with_replicates', {'primary': True}, [],'d2'],
+        ['wrangler_checks/replicate_file_reporting', {'primary': True}, [], 'd3']
     ],
     'six_hour_checks': [
-        ['system_checks/elastic_beanstalk_health', {}, [], 's1'],
-        ['system_checks/status_of_elasticsearch_indices', {}, [], 's2'],
-        ['system_checks/indexing_records', {}, [], 's3'],
-        ['wrangler_checks/item_counts_by_type', {}, [], 's4'],
-        ['wrangler_checks/change_in_item_counts', {}, [], 's5'],
-        ['system_checks/indexing_progress', {}, [], 's6']
+        ['system_checks/elastic_beanstalk_health', {'primary': True}, [], 's1'],
+        ['system_checks/status_of_elasticsearch_indices', {'primary': True}, [], 's2'],
+        ['system_checks/indexing_records', {'primary': True}, [], 's3'],
+        ['wrangler_checks/item_counts_by_type', {'primary': True}, [], 's4'],
+        ['wrangler_checks/change_in_item_counts', {'primary': True}, [], 's5'],
+        ['system_checks/indexing_progress', {'primary': True}, [], 's6']
     ],
     'two_hour_checks': [
-        ['wrangler_checks/identify_files_without_filesize', {}, [], 't1'],
-        ['wrangler_checks/item_counts_by_type', {}, [], 't2'],
-        ['system_checks/indexing_progress', {}, [], 't3'],
-        ['system_checks/staging_deployment', {}, [], 't4']
+        ['wrangler_checks/identify_files_without_filesize', {'primary': True}, [], 't1'],
+        ['wrangler_checks/item_counts_by_type', {'primary': True}, [], 't2'],
+        ['system_checks/indexing_progress', {'primary': True}, [], 't3'],
+        ['system_checks/staging_deployment', {'primary': True}, [], 't4']
     ]
 }
 
@@ -65,11 +65,11 @@ TEST_CHECK_GROUPS = {
 
 TEST_ACTION_GROUPS = {
     'add_random_test_nums': [
-        ['test_checks/add_random_test_nums', {}, ['tag1'], 'tag2'],
-        ['test_checks/test_random_nums', {}, [], 'tag1'],
-        ['test_checks/test_random_nums', {}, ['tag1']] # purposefully malformed
+        ['test_checks/add_random_test_nums', {'primary': True}, ['tag1'], 'tag2'],
+        ['test_checks/test_random_nums', {'primary': True}, [], 'tag1'],
+        ['test_checks/test_random_nums', {'primary': True}, ['tag1']] # purposefully malformed
     ],
     'add_random_test_nums_solo': [
-        ['test_checks/add_random_test_nums', {}, [], 'tzg1']
+        ['test_checks/add_random_test_nums', {'primary': True}, [], 'tzg1']
     ]
 }

--- a/chalicelib/check_groups.py
+++ b/chalicelib/check_groups.py
@@ -41,9 +41,9 @@ CHECK_GROUPS = {
 
 ACTION_GROUPS = {
     'patch_file_size': [
-        ['wrangler_checks/identify_files_without_filesize', {'search_add_on': '&datastore=database'}, [], 'pfs1'],
+        ['wrangler_checks/identify_files_without_filesize', {'primary': True, 'search_add_on': '&datastore=database'}, [], 'pfs1'],
         ['wrangler_checks/patch_file_size', {}, ['pfs1'], 'pfs2'],
-        ['wrangler_checks/identify_files_without_filesize', {'search_add_on': '&datastore=database'}, ['pfs2'], 'pfs3']
+        ['wrangler_checks/identify_files_without_filesize', {'primary': True, 'search_add_on': '&datastore=database'}, ['pfs2'], 'pfs3']
     ]
 }
 
@@ -52,17 +52,17 @@ ACTION_GROUPS = {
 
 TEST_CHECK_GROUPS = {
     'all_checks': [
-        ['wrangler_checks/items_created_in_the_past_day', {'primary': True}, [], 'all1'],
-        ['wrangler_checks/files_associated_with_replicates', {'primary': True}, [],'all2'],
-        ['wrangler_checks/replicate_file_reporting', {'primary': True}, [], 'all3'],
-        ['system_checks/elastic_beanstalk_health', {'primary': True}, [], 'all4'],
-        ['system_checks/status_of_elasticsearch_indices', {'primary': True}, [], 'all5'],
-        ['system_checks/indexing_records', {'primary': True}, [], 'all6'],
-        ['wrangler_checks/item_counts_by_type', {'primary': True}, [], 'all7'],
-        ['wrangler_checks/change_in_item_counts', {'primary': True}, ['all7'], 'all8'],
-        ['system_checks/indexing_progress', {'primary': True}, [], 'all9'],
-        ['wrangler_checks/identify_files_without_filesize', {'primary': True}, [], 'all10'],
-        ['system_checks/staging_deployment', {'primary': True}, [], 'all11']
+        ['wrangler_checks/items_created_in_the_past_day', {}, [], 'all1'],
+        ['wrangler_checks/files_associated_with_replicates', {}, [],'all2'],
+        ['wrangler_checks/replicate_file_reporting', {}, [], 'all3'],
+        ['system_checks/elastic_beanstalk_health', {}, [], 'all4'],
+        ['system_checks/status_of_elasticsearch_indices', {}, [], 'all5'],
+        ['system_checks/indexing_records', {}, [], 'all6'],
+        ['wrangler_checks/item_counts_by_type', {}, [], 'all7'],
+        ['wrangler_checks/change_in_item_counts', {}, ['all7'], 'all8'],
+        ['system_checks/indexing_progress', {}, [], 'all9'],
+        ['wrangler_checks/identify_files_without_filesize', {}, [], 'all10'],
+        ['system_checks/staging_deployment', {}, [], 'all11']
     ],
     'malformed_test_checks': [
         [{}, []], # bad

--- a/chalicelib/check_groups.py
+++ b/chalicelib/check_groups.py
@@ -83,11 +83,11 @@ TEST_CHECK_GROUPS = {
 
 TEST_ACTION_GROUPS = {
     'add_random_test_nums': [
-        ['test_checks/add_random_test_nums', {'primary': True}, ['tag1'], 'tag2'],
+        ['test_checks/add_random_test_nums', {}, ['tag1'], 'tag2'],
         ['test_checks/test_random_nums', {'primary': True}, [], 'tag1'],
         ['test_checks/test_random_nums', {'primary': True}, ['tag1']] # purposefully malformed
     ],
     'add_random_test_nums_solo': [
-        ['test_checks/add_random_test_nums', {'primary': True}, [], 'tzg1']
+        ['test_checks/add_random_test_nums', {}, [], 'tzg1']
     ]
 }

--- a/chalicelib/check_groups.py
+++ b/chalicelib/check_groups.py
@@ -14,19 +14,6 @@ CHECK_MODULES = [
 # define check_groups within this dict
 
 CHECK_GROUPS = {
-    'all_checks': [
-        ['wrangler_checks/items_created_in_the_past_day', {'primary': True}, [], 'all1'],
-        ['wrangler_checks/files_associated_with_replicates', {'primary': True}, [],'all2'],
-        ['wrangler_checks/replicate_file_reporting', {'primary': True}, [], 'all3'],
-        ['system_checks/elastic_beanstalk_health', {'primary': True}, [], 'all4'],
-        ['system_checks/status_of_elasticsearch_indices', {'primary': True}, [], 'all5'],
-        ['system_checks/indexing_records', {'primary': True}, [], 'all6'],
-        ['wrangler_checks/item_counts_by_type', {'primary': True}, [], 'all7'],
-        ['wrangler_checks/change_in_item_counts', {'primary': True}, ['all7'], 'all8'],
-        ['system_checks/indexing_progress', {'primary': True}, [], 'all9'],
-        ['wrangler_checks/identify_files_without_filesize', {'primary': True}, [], 'all10'],
-        ['system_checks/staging_deployment', {'primary': True}, [], 'all11']
-    ],
     'daily_checks': [
         ['wrangler_checks/items_created_in_the_past_day', {'primary': True}, [], 'd1'],
         ['wrangler_checks/files_associated_with_replicates', {'primary': True}, [],'d2'],
@@ -64,6 +51,19 @@ ACTION_GROUPS = {
 ######## don't use the check groups below! just for testing ########
 
 TEST_CHECK_GROUPS = {
+    'all_checks': [
+        ['wrangler_checks/items_created_in_the_past_day', {'primary': True}, [], 'all1'],
+        ['wrangler_checks/files_associated_with_replicates', {'primary': True}, [],'all2'],
+        ['wrangler_checks/replicate_file_reporting', {'primary': True}, [], 'all3'],
+        ['system_checks/elastic_beanstalk_health', {'primary': True}, [], 'all4'],
+        ['system_checks/status_of_elasticsearch_indices', {'primary': True}, [], 'all5'],
+        ['system_checks/indexing_records', {'primary': True}, [], 'all6'],
+        ['wrangler_checks/item_counts_by_type', {'primary': True}, [], 'all7'],
+        ['wrangler_checks/change_in_item_counts', {'primary': True}, ['all7'], 'all8'],
+        ['system_checks/indexing_progress', {'primary': True}, [], 'all9'],
+        ['wrangler_checks/identify_files_without_filesize', {'primary': True}, [], 'all10'],
+        ['system_checks/staging_deployment', {'primary': True}, [], 'all11']
+    ],
     'malformed_test_checks': [
         [{}, []], # bad
         ['system_checks/indexing_progress', []], # bad

--- a/chalicelib/check_groups.py
+++ b/chalicelib/check_groups.py
@@ -14,6 +14,19 @@ CHECK_MODULES = [
 # define check_groups within this dict
 
 CHECK_GROUPS = {
+    'all_checks': [
+        ['wrangler_checks/items_created_in_the_past_day', {'primary': True}, [], 'all1'],
+        ['wrangler_checks/files_associated_with_replicates', {'primary': True}, [],'all2'],
+        ['wrangler_checks/replicate_file_reporting', {'primary': True}, [], 'all3'],
+        ['system_checks/elastic_beanstalk_health', {'primary': True}, [], 'all4'],
+        ['system_checks/status_of_elasticsearch_indices', {'primary': True}, [], 'all5'],
+        ['system_checks/indexing_records', {'primary': True}, [], 'all6'],
+        ['wrangler_checks/item_counts_by_type', {'primary': True}, [], 'all7'],
+        ['wrangler_checks/change_in_item_counts', {'primary': True}, ['all7'], 'all8'],
+        ['system_checks/indexing_progress', {'primary': True}, [], 'all9'],
+        ['wrangler_checks/identify_files_without_filesize', {'primary': True}, [], 'all10'],
+        ['system_checks/staging_deployment', {'primary': True}, [], 'all11']
+    ],
     'daily_checks': [
         ['wrangler_checks/items_created_in_the_past_day', {'primary': True}, [], 'd1'],
         ['wrangler_checks/files_associated_with_replicates', {'primary': True}, [],'d2'],
@@ -24,7 +37,7 @@ CHECK_GROUPS = {
         ['system_checks/status_of_elasticsearch_indices', {'primary': True}, [], 's2'],
         ['system_checks/indexing_records', {'primary': True}, [], 's3'],
         ['wrangler_checks/item_counts_by_type', {'primary': True}, [], 's4'],
-        ['wrangler_checks/change_in_item_counts', {'primary': True}, [], 's5'],
+        ['wrangler_checks/change_in_item_counts', {'primary': True}, ['s4'], 's5'],
         ['system_checks/indexing_progress', {'primary': True}, [], 's6']
     ],
     'two_hour_checks': [
@@ -60,6 +73,11 @@ TEST_CHECK_GROUPS = {
         ['wrangler_checks/items_created_in_the_past_day', {'item_type': 'Biosample'}, [], 'wt1'],
         ['wrangler_checks/items_created_in_the_past_day', {'item_type': 'Experiment'}, ['wt1'], 'wt2'],
         ['wrangler_checks/items_created_in_the_past_day', {'item_type': 'File'}, ['wt2'], 'wt3']
+    ],
+    'valid_test_checks': [
+        ['test_checks/add_random_test_nums', {'primary': True}, ['tt3'], 'tt1'],
+        ['test_checks/add_random_test_nums', {'primary': True}, [], 'tt2'],
+        ['test_checks/add_random_test_nums', {'primary': True}, ['tt2'], 'tt3']
     ]
 }
 

--- a/chalicelib/check_utils.py
+++ b/chalicelib/check_utils.py
@@ -46,35 +46,6 @@ def get_check_strings(specific_check=None):
         return list(set(all_checks))
 
 
-def run_check_group(connection, name):
-    """
-    This is a test function, DEPRECATED in favor of app_utils.queue_check_group.
-    The issue is that run_check_group will run checks synchronously in one lambda.
-
-    WILL NOT RUN ACTION GROUPS.
-    """
-    check_results = []
-    check_group = fetch_check_group(name)
-    if not check_group:
-        return check_results
-    group_timestamp = datetime.datetime.utcnow().isoformat()
-    for check_info in check_group:
-        if len(check_info) != 4:
-            check_results.append(' '.join(['ERROR with', str(check_info), 'in group:', name]))
-        else:
-            # add uuid to each kwargs dict if not already specified
-            # this will have the effect of giving all checks the same id
-            # and combining results from repeats in the same check_group
-            [check_str, check_kwargs, check_deps, dep_id] = check_info
-            if 'uuid' not in check_kwargs:
-                check_kwargs['uuid'] = group_timestamp
-            # nothing done with dependencies yet
-            result = run_check_or_action(connection, check_str, check_kwargs)
-            if result:
-                check_results.append(result)
-    return check_results
-
-
 def get_check_group_latest(connection, name):
     """
     Initialize check results for each check in a group and get latest results,

--- a/chalicelib/check_utils.py
+++ b/chalicelib/check_utils.py
@@ -23,11 +23,11 @@ for check_mod in CHECK_MODULES:
 
 def get_check_strings(specific_check=None):
     """
-    Return check formatted check strings (<module>/<check_name>) for checks.
+    Return a list of all formatted check strings (<module>/<check_name>) in system.
     By default runs on all checks (specific_check == None), but can be used
     to get the check string of a certain check name as well.
 
-    IMPORTANT: any checks in test_checks module are excluded from 'all'
+    IMPORTANT: any checks in test_checks module are excluded.
     """
     all_checks = []
     for check_mod in CHECK_MODULES:
@@ -37,7 +37,7 @@ def get_check_strings(specific_check=None):
                 check_str = '/'.join([check_mod, method.__name__])
                 if specific_check and specific_check == method.__name__:
                     return check_str
-                elif check_mod != 'test_checks': # exclude test checks from 'all'
+                elif check_mod != 'test_checks':
                     all_checks.append(check_str)
     if specific_check:
         # if we've gotten here, it means the specific check was not checks_found
@@ -103,11 +103,6 @@ def fetch_check_group(name):
     Will be none if the group is not defined.
     Special case for all_checks, which gets all checks and uses default kwargs
     """
-    if name == 'all':
-        all_checks_strs = get_check_strings()
-        # dependecy id's are not used (since there are no dependencies) so arbitrarily set to '_'
-        all_checks_group = [[check_str, {}, [], '_'] for check_str in all_checks_strs]
-        return all_checks_group
     group = CHECK_GROUPS.get(name, None)
     # maybe it's a test groups
     if not group:
@@ -121,7 +116,7 @@ def fetch_check_group(name):
 
 def fetch_action_group(name):
     """
-    Used only for ACTION_GROUPS, which mix actions and checks. Does NOT use 'all'
+    Used only for ACTION_GROUPS, which mix actions and checks
     """
     group = ACTION_GROUPS.get(name, None)
     # maybe it's a test groups

--- a/chalicelib/check_utils.py
+++ b/chalicelib/check_utils.py
@@ -46,10 +46,12 @@ def get_check_strings(specific_check=None):
         return list(set(all_checks))
 
 
-def get_check_group_latest(connection, name):
+def get_check_group_results(connection, name, use_latest=False):
     """
     Initialize check results for each check in a group and get latest results,
     sorted alphabetically
+    By default, gets the 'primary' results. If use_latest is True, get the
+    'latest' results instead.
     """
     latest_results = []
     check_group = fetch_check_group(name)
@@ -60,7 +62,10 @@ def get_check_group_latest(connection, name):
             continue
         check_name = check_info[0].strip().split('/')[1]
         tempCheck = init_check_res(connection, check_name)
-        found = tempCheck.get_latest_result()
+        if use_latest:
+            found = tempCheck.get_latest_result()
+        else:
+            found = tempCheck.get_primary_result()
         # checks with no records will return None. Skip IGNORE checks
         if found and found.get('status') != 'IGNORE':
             latest_results.append(found)

--- a/chalicelib/run_result.py
+++ b/chalicelib/run_result.py
@@ -60,7 +60,7 @@ class RunResult(object):
         return self.get_s3_object(best_match[0])
 
 
-    def get_s3_object(key):
+    def get_s3_object(self, key):
         """
         Returns None if not present, otherwise returns a JSON parsed res.
         """

--- a/chalicelib/run_result.py
+++ b/chalicelib/run_result.py
@@ -200,6 +200,9 @@ class ActionResult(RunResult):
 
 
     def store_result(self):
+        # bail if do_not_store is True within kwargs
+        if self.kwargs.get('do_not_store', False) == True:
+            return {}
         # normalize status, probably not the optimal place to do this
         if self.status.upper() not in ['DONE', 'FAIL', 'PEND']:
             self.status = 'FAIL'

--- a/chalicelib/run_result.py
+++ b/chalicelib/run_result.py
@@ -120,7 +120,8 @@ class CheckResult(RunResult):
                 except ValueError:
                     parsed_res = stamp_res
                 for key, val in parsed_res.items():
-                    setattr(self, key, val)
+                    if key not in ['kwargs']: # dont copy kwargs
+                        setattr(self, key, val)
                 super().__init__(s3_connection, name)
                 return
             else:
@@ -213,8 +214,9 @@ class ActionResult(RunResult):
             self.description = 'Malformed status; look at Foursight action definition.'
         uuid = datetime.datetime.utcnow().isoformat()
         formatted = self.format_result(uuid)
-        is_primary = self.kwargs.get('primary', False) == True
-        return self.store_formatted_result(uuid, formatted, primary=is_primary)
+        # action results are always stored as 'primary' and can be fetched
+        # with the get_latest_result method.
+        return self.store_formatted_result(uuid, formatted, primary=True)
 
 
 

--- a/chalicelib/run_result.py
+++ b/chalicelib/run_result.py
@@ -31,7 +31,7 @@ class RunResult(object):
         return self.get_s3_object(primary_key)
 
 
-    def get_closest_result(self, diff_hours, diff_mins=0):
+    def get_closest_result(self, diff_hours=0, diff_mins=0):
         """
         Returns check result that is closest to the current time minus
         diff_hours and diff_mins (both integers).

--- a/chalicelib/run_result.py
+++ b/chalicelib/run_result.py
@@ -16,6 +16,9 @@ class RunResult(object):
 
 
     def get_latest_result(self):
+        """
+        Returns the latest (primary) result
+        """
         latest_key = ''.join([self.name, '/latest', self.extension])
         result = self.s3_connection.get_object(latest_key)
         if result is None:
@@ -72,7 +75,7 @@ class RunResult(object):
         return all_results
 
 
-    def store_formatted_result(self, uuid, formatted, is_primary=False):
+    def store_formatted_result(self, uuid, formatted, primary=False):
         """
         Store the result in s3. Always makes an entry with key equal to the
         uuid timestamp. If is_primary, will also save result the the 'latest'
@@ -84,7 +87,7 @@ class RunResult(object):
         # store the timestamped result
         self.s3_connection.put_object(time_key, s3_formatted)
         # put result as 'latest' key is this is primary
-        if is_primary:
+        if primary:
             self.s3_connection.put_object(latest_key, s3_formatted)
         # return stored data in case we're interested
         return formatted
@@ -170,6 +173,7 @@ class CheckResult(RunResult):
             self.description = 'Malformed status; look at Foursight check definition.'
         # if there's a set uuid field, use that instead of curr utc time
         uuid = self.uuid if self.uuid else datetime.datetime.utcnow().isoformat()
+        formatted = self.format_result(uuid)
         is_primary = self.kwargs.get('primary', False) == True
         return self.store_formatted_result(uuid, formatted, primary=is_primary)
 

--- a/chalicelib/run_result.py
+++ b/chalicelib/run_result.py
@@ -20,15 +20,7 @@ class RunResult(object):
         Returns the latest result (the last check run)
         """
         latest_key = ''.join([self.name, '/latest', self.extension])
-        result = self.s3_connection.get_object(latest_key)
-        if result is None:
-            return None
-        # see if data is in json format
-        try:
-            json_result = json.loads(result)
-        except ValueError:
-            return result
-        return json_result
+        return self.get_s3_object(latest_key)
 
 
     def get_primary_result(self):
@@ -36,15 +28,7 @@ class RunResult(object):
         Returns the most recent primary result run (with 'primary'=True in kwargs)
         """
         primary_key = ''.join([self.name, '/primary', self.extension])
-        result = self.s3_connection.get_object(primary_key)
-        if result is None:
-            return None
-        # see if data is in json format
-        try:
-            json_result = json.loads(result)
-        except ValueError:
-            return result
-        return json_result
+        return self.get_s3_object(primary_key)
 
 
     def get_closest_result(self, diff_hours, diff_mins=0):
@@ -73,7 +57,16 @@ class RunResult(object):
         desired_time = (datetime.datetime.utcnow() -
             datetime.timedelta(hours=diff_hours, minutes=diff_mins))
         best_match = get_closest(check_tuples, desired_time)
-        result = self.s3_connection.get_object(best_match[0])
+        return self.get_s3_object(best_match[0])
+
+
+    def get_s3_object(key):
+        """
+        Returns None if not present, otherwise returns a JSON parsed res.
+        """
+        result = self.s3_connection.get_object(key)
+        if result is None:
+            return None
         # see if data is in json format
         try:
             json_result = json.loads(result)

--- a/chalicelib/system_checks.py
+++ b/chalicelib/system_checks.py
@@ -119,10 +119,10 @@ def status_of_elasticsearch_indices(connection, **kwargs):
 @check_function()
 def indexing_progress(connection, **kwargs):
     check = init_check_res(connection, 'indexing_progress')
-    # get latest and db/es counts closest to 2 hrs ago
+    # get latest and db/es counts closest to 10 mins ago
     counts_check = init_check_res(connection, 'item_counts_by_type')
     latest = counts_check.get_primary_result()
-    prior = counts_check.get_closest_result(2)
+    prior = counts_check.get_closest_result(diff_mins=10)
     if not latest.get('full_output') or not prior.get('full_output'):
         check.status = 'ERROR'
         check.description = 'There are no item_counts_by_type results to run this check with.'
@@ -133,17 +133,17 @@ def indexing_progress(connection, **kwargs):
     if diff_unindexed == 0 and latest_unindexed != 0:
         check.status = 'FAIL'
         check.description = ' '.join(['Total number of unindexed items is',
-            str(latest_unindexed), 'and has not changed in the past two hours.',
+            str(latest_unindexed), 'and has not changed in the past ten minutes.',
             'The indexer may be malfunctioning.'])
     elif diff_unindexed > 0:
         check.status = 'WARN'
         check.description = ' '.join(['Total number of unindexed items has increased by',
-            str(diff_unindexed), 'in the past two hours. Remaining items to index:',
+            str(diff_unindexed), 'in the past ten minutes. Remaining items to index:',
             str(latest_unindexed)])
     else:
         check.status = 'PASS'
         check.description = ' '.join(['Indexing seems healthy. There are', str(latest_unindexed),
-        'remaining items to index, a change of', str(diff_unindexed), 'from two hours ago.'])
+        'remaining items to index, a change of', str(diff_unindexed), 'from ten minutes ago.'])
     return check
 
 

--- a/chalicelib/system_checks.py
+++ b/chalicelib/system_checks.py
@@ -121,7 +121,7 @@ def indexing_progress(connection, **kwargs):
     check = init_check_res(connection, 'indexing_progress')
     # get latest and db/es counts closest to 2 hrs ago
     counts_check = init_check_res(connection, 'item_counts_by_type')
-    latest = counts_check.get_latest_result()
+    latest = counts_check.get_primary_result()
     prior = counts_check.get_closest_result(2)
     if not latest.get('full_output') or not prior.get('full_output'):
         check.status = 'ERROR'

--- a/chalicelib/templates/template.html
+++ b/chalicelib/templates/template.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="html-scroll">
 <head>
     <meta charset="utf-8">
     <title>Foursight</title>
@@ -12,6 +12,9 @@
     <!-- Get variables needed within js from jinja -->
     <meta id="fs_domain" data-domain="{{domain}}">
     <style type="text/css">
+    .html-scroll {
+        overflow-y: scroll;
+    }
     .container {
         max-width: 1400px;
         padding-top: 10px;
@@ -37,6 +40,10 @@
     }
     .commonstyle {
         margin: 0px 0px 5px 5px;
+    }
+    .collapse-div{
+        overflow: hidden;
+        clear: both;
     }
     .own-line {
         display: block;
@@ -66,6 +73,10 @@
     .center-element {
         text-align: center;
     }
+    .title-hover:hover, .title-hover:active, .title-hover:visited, .title-hover:focus{
+        text-decoration: none;
+        color: #000;
+    }
     li {
         list-style-type: none;
         padding: 0;
@@ -73,6 +84,13 @@
     }
     a {
         color: inherit;
+    }
+    dl {
+        margin-bottom: 0px;
+    }
+    dd {
+        margin-left: 20px;
+        margin-bottom: 5px;
     }
     </style>
 </head>
@@ -114,7 +132,7 @@
                         <div class="{{'check-' + check['status'].lower() + ' boxstyle'}}">
                             <h5 style='margin:10px 5px 10px 5px;'}}>
                                 {% if check.content %}
-                                    <a data-toggle="collapse" href={{'#' + env['environment'] + '-' + check['name']}}>{{check.title}}</a>
+                                    <a class="title-hover" data-toggle="collapse" href={{'#' + env['environment'] + '-' + check['name']}}>{{check.title}}</a>
                                 {% else %}
                                     <span>{{check.title}}</span>
                                 {% endif %}
@@ -130,58 +148,75 @@
                                 {% endif %}
                             </h5>
                             {% if check.content %}
-                            <div class="collapse commonstyle" id={{env['environment'] + '-' + check['name']}}>
-                                {% if check.get('description') %}
-                                    <div class="commonstyle own-line">{{check.description}}</div>
-                                {% endif %}
-                                {% if check.get('ff_link') %}
-                                    <a href={{check['ff_link']}} target="_blank" class="commonstyle own-line">{{check.ff_link}}</a>
-                                {% endif %}
-                                {% if check.get('brief_output')%}
-                                    <button class='commonstyle btn btn-default btn-sm' data-toggle="collapse" data-target={{'#' + env['environment'] + '-' + check['name'] + '-brief'}}>
-                                        Toggle brief output
-                                    </button>
-                                    <div class="commonstyle collapse" id={{env['environment'] + '-' + check['name'] + '-brief'}}>
-                                        <pre><code>{{check.brief_output}}</code></pre>
-                                    </div>
-                                {% endif %}
-                                {% if check.get('full_output')%}
-                                    <button class='commonstyle btn btn-default btn-sm' data-toggle="collapse" data-target={{'#' + env['environment'] + '-' + check['name'] + '-full'}}>
-                                        Toggle full output
-                                    </button>
-                                    <div class="commonstyle collapse" id={{env['environment'] + '-' + check['name'] + '-full'}}>
-                                        <pre><code>{{check.full_output}}</code></pre>
-                                    </div>
-                                {% endif %}
-                                {% if check.get('admin_output') and is_admin %}
-                                    <button class='commonstyle btn btn-default btn-sm' data-toggle="collapse" data-target={{'#' + env['environment'] + '-' + check['name'] + '-admin'}}>
-                                        Toggle admin output
-                                    </button>
-                                    <div class="commonstyle collapse" id={{env['environment'] + '-' + check['name'] + '-admin'}}>
-                                        <pre><code>{{check.admin_output}}</code></pre>
-                                    </div>
-                                {% endif %}
-                                {% if check.get('latest_action') %}
-                                    <button class='commonstyle btn btn-default btn-sm' data-toggle="collapse" data-target={{'#' + env['environment'] + '-' + check['name'] + '-latest-action'}}>
-                                        Toggle latest action
-                                    </button>
-                                    <div class="commonstyle collapse" id={{env['environment'] + '-' + check['name'] + '-latest-action'}}>
-                                        <pre><code>{{check.latest_action}}</code></pre>
-                                    </div>
-                                {% endif %}
-                                {% if check.get('action') and is_admin %}
-                                    <form class="commonstyle" action={{"/api/view/" + env['environment'] + '/' + check['action'] + '/action'}} method="get">
-                                        {% if not check.get('allow_action') or running_checks != '0' or queued_checks != '0' %}
-                                            <button class="btn btn-danger btn-sm" type="submit" disabled>
-                                                {{' '.join(check['action'].split('_')).title()}}
-                                            </button>
-                                        {% else %}
-                                            <button class="btn btn-danger btn-sm" type="submit">
-                                                {{' '.join(check['action'].split('_')).title()}}
-                                            </button>
+                            <div class="collapse collapse-div commonstyle container-fluid" id={{env['environment'] + '-' + check['name']}}>
+                                <hr style="margin:0px 0px 8px 0px; border-top:1px solid #ccc;">
+                                <div class='row'>
+                                    <div class="col-sm-9">
+                                        {% if check.get('description') %}
+                                            <div class="commonstyle own-line">{{check.description}}</div>
                                         {% endif %}
-                                    </form>
-                                {% endif %}
+                                        {% if check.get('ff_link') %}
+                                            <a href={{check['ff_link']}} target="_blank" class="commonstyle own-line">{{check.ff_link}}</a>
+                                        {% endif %}
+                                        {% if check.get('brief_output')%}
+                                            <button class='commonstyle own-line btn btn-default btn-sm' data-toggle="collapse" data-target={{'#' + env['environment'] + '-' + check['name'] + '-brief'}}>
+                                                Toggle brief output
+                                            </button>
+                                            <div class="commonstyle collapse" id={{env['environment'] + '-' + check['name'] + '-brief'}}>
+                                                <pre><code>{{check.brief_output}}</code></pre>
+                                            </div>
+                                        {% endif %}
+                                        {% if check.get('full_output')%}
+                                            <button class='commonstyle own-line btn btn-default btn-sm' data-toggle="collapse" data-target={{'#' + env['environment'] + '-' + check['name'] + '-full'}}>
+                                                Toggle full output
+                                            </button>
+                                            <div class="commonstyle collapse" id={{env['environment'] + '-' + check['name'] + '-full'}}>
+                                                <pre><code>{{check.full_output}}</code></pre>
+                                            </div>
+                                        {% endif %}
+                                        {% if check.get('admin_output') and is_admin %}
+                                            <button class='commonstyle own-line btn btn-default btn-sm' data-toggle="collapse" data-target={{'#' + env['environment'] + '-' + check['name'] + '-admin'}}>
+                                                Toggle admin output
+                                            </button>
+                                            <div class="commonstyle collapse" id={{env['environment'] + '-' + check['name'] + '-admin'}}>
+                                                <pre><code>{{check.admin_output}}</code></pre>
+                                            </div>
+                                        {% endif %}
+                                        {% if check.get('latest_action') %}
+                                            <button class='commonstyle own-line btn btn-default btn-sm' data-toggle="collapse" data-target={{'#' + env['environment'] + '-' + check['name'] + '-latest-action'}}>
+                                                Toggle latest action
+                                            </button>
+                                            <div class="commonstyle collapse" id={{env['environment'] + '-' + check['name'] + '-latest-action'}}>
+                                                <pre><code>{{check.latest_action}}</code></pre>
+                                            </div>
+                                        {% endif %}
+                                        {% if check.get('action') and is_admin %}
+                                            <form class="commonstyle own-line" action={{"/api/view/" + env['environment'] + '/' + check['action'] + '/action'}} method="get">
+                                                {% if not check.get('allow_action') or running_checks != '0' or queued_checks != '0' %}
+                                                    <button class="btn btn-danger btn-sm" type="submit" disabled>
+                                                        {{' '.join(check['action'].split('_')).title()}}
+                                                    </button>
+                                                {% else %}
+                                                    <button class="btn btn-danger btn-sm" type="submit">
+                                                        {{' '.join(check['action'].split('_')).title()}}
+                                                    </button>
+                                                {% endif %}
+                                            </form>
+                                        {% endif %}
+                                    </div>
+                                    <div class="col-sm-3 pull-right">
+                                        {% if check.get('kwargs') %}
+                                        <dl>
+                                            {% for kwarg in check['kwargs'] %}
+                                                {% if kwarg != 'uuid' %}
+                                                    <dt>{{kwarg}}</dt>
+                                                    <dd>{{check['kwargs'][kwarg]}}</dd>
+                                                {% endif %}
+                                            {% endfor %}
+                                        </dl>
+                                        {% endif %}
+                                    </div>
+                                </div>
                             </div>
                             {% endif %}
                         </div>

--- a/chalicelib/test_checks.py
+++ b/chalicelib/test_checks.py
@@ -3,8 +3,7 @@ from .utils import (
     check_function,
     init_check_res,
     action_function,
-    init_action_res,
-    build_dummy_result
+    init_action_res
 )
 import requests
 import sys
@@ -42,7 +41,7 @@ def test_random_nums(connection, **kwargs):
         output.append(random.randint(1,100))
     check.full_output = output
     check.description = 'A test check'
-    return check.store_result()
+    return check
 
 
 @action_function(offset=0)
@@ -55,4 +54,4 @@ def add_random_test_nums(connection, **kwargs):
     action.output = total
     action.status = 'DONE'
     action.description = 'A test action'
-    return action.store_result()
+    return action

--- a/chalicelib/test_checks.py
+++ b/chalicelib/test_checks.py
@@ -48,10 +48,14 @@ def test_random_nums(connection, **kwargs):
 def add_random_test_nums(connection, **kwargs):
     action = init_action_res(connection, 'add_random_test_nums')
     check = init_check_res(connection, 'test_random_nums')
+    # output includes primary and latest results, to compare
     check_latest = check.get_latest_result()
-    nums = check_latest.get('full_output', [])
-    total = sum(nums) + kwargs.get('offset', 0)
-    action.output = total
+    nums_latest = check_latest.get('full_output', [])
+    total_latest = sum(nums_latest) + kwargs.get('offset', 0)
+    check_primary = check.get_primary_result()
+    nums_primary = check_primary.get('full_output', [])
+    total_primary = sum(nums_primary) + kwargs.get('offset', 0)
+    action.output = {'latest': total_latest, 'primary': total_primary}
     action.status = 'DONE'
     action.description = 'A test action'
     return action

--- a/chalicelib/utils.py
+++ b/chalicelib/utils.py
@@ -78,7 +78,8 @@ def check_function(*default_args, **default_kwargs):
             for key in default_kwargs:
                 if key not in kwargs:
                     kwargs[key] = default_kwargs[key]
-            return func(*args, **kwargs)
+            check = func(*args, **kwargs)
+            return store_result_wrapper(check, kwargs, is_check=True)
         wrapper.check_decorator = CHECK_DECO
         return wrapper
     return check_deco
@@ -98,7 +99,42 @@ def action_function(*default_args, **default_kwargs):
             for key in default_kwargs:
                 if key not in kwargs:
                     kwargs[key] = default_kwargs[key]
-            return func(*args, **kwargs)
+            action = func(*args, **kwargs)
+            return store_result_wrapper(action, kwargs, is_action=True)
         wrapper.check_decorator = ACTION_DECO
         return wrapper
     return action_deco
+
+
+def store_result_wrapper(result, kwargs, is_check=False, is_action=False):
+    """
+    Result should be an ActionResult or CheckResult. Raises an exception if not.
+    Sets the kwargs attr of the result and calls store_result method.
+    """
+    error_message = None
+    class_name = type(result).__name__
+    if is_check and class_name != 'CheckResult':
+        error_message = 'Check function must return a CheckResult object. Initialize one with init_check_res.'
+    elif is_action and class_name != 'ActionResult':
+        error_message = 'Action functions must return a ActionResult object. Initialize one with init_action_res.'
+    store_method = getattr(result, 'store_result', None)
+    if not callable(store_method):
+        error_message = 'Do not overwrite the store_result method of the check or action result.'
+    if error_message:
+        raise BadCheckOrAcion(error_message)
+    else:
+        # set the kwargs parameter
+        result.kwargs = kwargs
+        return result.store_result()
+
+
+class BadCheckOrAcion(Exception):
+    """
+    Generic exception for a badly written check or library.
+    __init__ takes some string error message
+    """
+    def __init__(self, message=None):
+        # default error message if none provided
+        if message is None:
+            message = "Check or action function seems to be malformed."
+        super().__init__(message)

--- a/chalicelib/utils.py
+++ b/chalicelib/utils.py
@@ -110,14 +110,14 @@ def store_result_wrapper(result, kwargs, is_check=False, is_action=False):
     if not callable(store_method):
         error_message = 'Do not overwrite the store_result method of the check or action result.'
     if error_message:
-        raise BadCheckOrAcion(error_message)
+        raise BadCheckOrAction(error_message)
     else:
         # set the kwargs parameter
         result.kwargs = kwargs
         return result.store_result()
 
 
-class BadCheckOrAcion(Exception):
+class BadCheckOrAction(Exception):
     """
     Generic exception for a badly written check or library.
     __init__ takes some string error message

--- a/chalicelib/utils.py
+++ b/chalicelib/utils.py
@@ -31,17 +31,6 @@ def init_action_res(connection, name):
     """
     return ActionResult(connection.s3_connection, name)
 
-def build_dummy_result(check_name):
-    """
-    Simple function to return a dict consistent with a CheckResult dictionary
-    content but is not actually stored.
-    """
-    return {
-        'status': 'IGNORE',
-        'name': check_name,
-        'uuid': datetime.datetime.utcnow().isoformat()
-    }
-
 
 def get_methods_by_deco(cls, decorator):
     """

--- a/chalicelib/wrangler_checks.py
+++ b/chalicelib/wrangler_checks.py
@@ -33,10 +33,10 @@ def item_counts_by_type(connection, **kwargs):
         counts_res = requests.get(''.join([server,'counts?format=json']))
     except:
         check.status = 'ERROR'
-        return check.store_result()
+        return check
     if counts_res.status_code != 200:
         check.status = 'ERROR'
-        return check.store_result()
+        return check
     counts_json = json.loads(counts_res.text)
     for index in counts_json['db_es_compare']:
         counts = process_counts(counts_json['db_es_compare'][index])
@@ -57,7 +57,7 @@ def item_counts_by_type(connection, **kwargs):
     else:
         check.status = 'PASS'
     check.full_output = item_counts
-    return check.store_result()
+    return check
 
 
 @check_function()
@@ -71,7 +71,7 @@ def change_in_item_counts(connection, **kwargs):
     if not latest.get('full_output') or not prior.get('full_output'):
         check.status = 'ERROR'
         check.description = 'There are no counts_check results to run this check with.'
-        return check.store_result()
+        return check
     diff_counts = {}
     # drill into full_output
     latest = latest['full_output']
@@ -95,7 +95,7 @@ def change_in_item_counts(connection, **kwargs):
         check.description = 'DB counts have changed in past day; positive numbers represent an increase in current counts.'
     else:
         check.status = 'PASS'
-    return check.store_result()
+    return check
 
 
 @check_function(item_type='Item')
@@ -106,7 +106,7 @@ def items_created_in_the_past_day(connection, **kwargs):
     if not (fdn_conn and fdn_conn.check):
         check.status = 'ERROR'
         check.description = ''.join(['Could not establish a FDN_Connection using the FF env: ', connection.ff_env])
-        return check.store_result()
+        return check
     # date string of approx. one day ago in form YYYY-MM-DD
     date_str = (datetime.datetime.utcnow() - datetime.timedelta(days=1)).strftime('%Y-%m-%d')
     search_query = ''.join(['/search/?type=', item_type, '&limit=all&q=date_created:>=', date_str])
@@ -133,7 +133,7 @@ def items_created_in_the_past_day(connection, **kwargs):
     else:
         check.status = 'PASS'
         check.description = 'No items have been created in the past day.'
-    return check.store_result()
+    return check
 
 
 @check_function()
@@ -153,7 +153,7 @@ def files_associated_with_replicates(connection, **kwargs):
     if not (fdn_conn and fdn_conn.check):
         check.status = 'ERROR'
         check.description = ''.join(['Could not establish a FDN_Connection using the FF env: ', connection.ff_env])
-        return check.store_result()
+        return check
     total_replicates = None
     curr_from = 0
     limit = 100
@@ -184,7 +184,7 @@ def files_associated_with_replicates(connection, **kwargs):
             set_files[set_acc] = files
         curr_from += limit
     check.full_output = set_files
-    return check.store_result()
+    return check
 
 
 @check_function(delta_hours=24)
@@ -235,7 +235,7 @@ def replicate_file_reporting(connection, **kwargs):
     if not isinstance(latest_results, dict) or not isinstance(prior_results, dict):
         check.status = 'ERROR'
         check.description = 'Could not generate report due to missing output of files_associated_with_replicates check.'
-        return check.store_result()
+        return check
     report = {}
     all_sets = list(set(latest_results.keys()).union(set(prior_results.keys())))
     for exp_set in all_sets:
@@ -254,7 +254,7 @@ def replicate_file_reporting(connection, **kwargs):
     else:
         check.status = 'PASS'
         check.description = ''.join(['No significant file changes to one or more experiment sets have occured in the last ', str(delta_hours), ' hours.'])
-    return check.store_result()
+    return check
 
 
 @check_function(search_add_on='&limit=all')
@@ -266,7 +266,7 @@ def identify_files_without_filesize(connection, **kwargs):
     if not (fdn_conn and fdn_conn.check):
         check.status = 'ERROR'
         check.description = ''.join(['Could not establish a FDN_Connection using the FF env: ', connection.ff_env])
-        return check.store_result()
+        return check
     search_url = '/search/?type=File&status=released%20to%20project&status=released&status=uploaded' + kwargs.get('search_add_on', '')
     search_res = ff_utils.get_metadata(search_url, connection=fdn_conn, frame='object')
     problem_files = []
@@ -287,7 +287,7 @@ def identify_files_without_filesize(connection, **kwargs):
         check.allow_action = True # allows the action to be run
     else:
         check.status = 'PASS'
-    return check.store_result()
+    return check
 
 
 @action_function()
@@ -315,4 +315,4 @@ def patch_file_size(connection, **kwargs):
                 action_logs['patch_success'].append(hit['accession'])
     action.status = 'DONE'
     action.output = action_logs
-    return action.store_result()
+    return action

--- a/chalicelib/wrangler_checks.py
+++ b/chalicelib/wrangler_checks.py
@@ -66,8 +66,8 @@ def change_in_item_counts(connection, **kwargs):
     check = init_check_res(connection, 'change_in_item_counts', runnable=True)
     counts_check = init_check_res(connection, 'item_counts_by_type')
     latest = counts_check.get_primary_result()
-    # get_item_counts run closest to 24 hours ago
-    prior = counts_check.get_closest_result(24)
+    # get_item_counts run closest to 10 mins
+    prior = counts_check.get_closest_result(diff_hours=24)
     if not latest.get('full_output') or not prior.get('full_output'):
         check.status = 'ERROR'
         check.description = 'There are no counts_check results to run this check with.'

--- a/chalicelib/wrangler_checks.py
+++ b/chalicelib/wrangler_checks.py
@@ -65,7 +65,7 @@ def change_in_item_counts(connection, **kwargs):
     # use this check to get the comparison
     check = init_check_res(connection, 'change_in_item_counts', runnable=True)
     counts_check = init_check_res(connection, 'item_counts_by_type')
-    latest = counts_check.get_latest_result()
+    latest = counts_check.get_primary_result()
     # get_item_counts run closest to 24 hours ago
     prior = counts_check.get_closest_result(24)
     if not latest.get('full_output') or not prior.get('full_output'):
@@ -230,7 +230,7 @@ def replicate_file_reporting(connection, **kwargs):
     delta_hours = kwargs.get('delta_hours')
     check = init_check_res(connection, 'replicate_file_reporting')
     files_check = init_check_res(connection, 'files_associated_with_replicates')
-    latest_results = files_check.get_latest_result().get('full_output')
+    latest_results = files_check.get_primary_result().get('full_output')
     prior_results = files_check.get_closest_result(delta_hours).get('full_output')
     if not isinstance(latest_results, dict) or not isinstance(prior_results, dict):
         check.status = 'ERROR'
@@ -298,7 +298,7 @@ def patch_file_size(connection, **kwargs):
     action_logs = {'s3_file_not_found': [], 'patch_failure': [], 'patch_success': []}
     # get latest results from identify_files_without_filesize
     filesize_check = init_check_res(connection, 'identify_files_without_filesize')
-    check_latest = filesize_check.get_latest_result() # what we want is in full_output
+    check_latest = filesize_check.get_primary_result() # what we want is in full_output
     for hit in check_latest.get('full_output', []):
         bucket = s3_obj.outfile_bucket if 'FileProcessed' in hit['@type'] else s3_obj.raw_file_bucket
         head_info = s3_obj.does_key_exist(hit['upload_key'], bucket)

--- a/deploy.py
+++ b/deploy.py
@@ -44,7 +44,10 @@ def build_config_and_deploy(stage):
     dev_secret = os.environ.get("DEV_SECRET")
     admin = os.environ.get("FS_ADMIN")
     if not (akey_secret and client_id and client_secret and dev_secret):
-        print('ERROR. You are missing one more more environment variables needed to deploy Foursight. Need: SECRET, CLIENT_ID, CLIENT_SECRET, DEV_SECRET.')
+        print(''.join(['ERROR. You are missing one more more environment ',
+        'variables needed to deploy Foursight.\n',
+        'Need: SECRET, CLIENT_ID, CLIENT_SECRET, DEV_SECRET, FS_ADMIN.'])
+        )
         sys.exit()
     for curr_stage in ['dev', 'prod']:
         CONFIG_BASE['stages'][curr_stage]['environment_variables']['SECRET'] = akey_secret

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -115,7 +115,7 @@ Let's say we want to make the action use a key word argument (`offset = 5`) and 
 
 Using techniques like the one above, you can make arbitrarily complicated combinations of actions and checks. One important use case is having a check run again after an action completes if the action would change the output of the check. This is especially important if a user might trigger the action another time based on the output of the check itself. A concrete example is a check that identifies all items in your system missing a certain field and an action that uses those check results to patch that field for all items. You would want to re-run the check after executing the action so that the UI displays the most up-to-date results for the check and so that nobody would accidentally run the action again after it had already been run.
 
-**Note:** You don't need to set `primary = True` as a key word argument for actions. The most recent action run will always be the one displayed on the UI (see the next section).
+**Note:** You don't need to set `primary=True` as a key word argument for actions. The latest action run will be stored with both the `latest` and `primary` tag in s3. Thus, the most recent action run will always be the one displayed on the UI (see the next section).
 
 ### Viewing action results
 The results of run actions can be seen using the `Toggle latest action` button in the linked check on the Foursight UI. This box will always show the most recent run of the linked action in JSON form.

--- a/docs/development_tips.md
+++ b/docs/development_tips.md
@@ -85,7 +85,7 @@ Just like testing individual action functions is very similar to testing individ
 
 ### Some other testing notes
 * By default, you will use the `dev` stage of Foursight from the Python interpreter and test.py. To change to `prod` (USE WITH CARE), use `app.STAGE = 'PROD'`.
-* You can get the latest check group results using `app.get_check_group_latest(connection, name)` given a Foursight connection and a valid check group name.
+* You can get the latest check group results using `app.get_check_group_results(connection, name)` given a Foursight connection and a valid check group name.
 
 ### Scheduling your check group
 Okay, so you've got a check group that you're confident in. To schedule it using a CRON or rate expression, go to the top of app.py and create a new scheduled function (leading with the `@app.schedule()` decorator). Two examples are below:

--- a/docs/development_tips.md
+++ b/docs/development_tips.md
@@ -63,26 +63,19 @@ Actions function very similarly to checks when run individually. In fact, testin
 ```
 
 ### Manual testing of your check group
-Let's say you want to run a whole check group and not an individual check. There are two ways to test this: `app.run_check_group`, which will run your checks synchronously. Alternatively, you can use `app.queue_check_group`, which causes your checks to run synchronously. The first function is useful for testing but is limited by its speed and may actually timeout if the checks take too long to run. The second function is actually who scheduled check groups are run, but it is difficult to track output. Below are examples of both from the Python interpreter with the example check group named `my_test_checks`.
+Let's say you want to run a whole check group and not an individual check. To test this, you can use `app.queue_check_group`, which causes your checks to run synchronously. This function is the one that is internally used to schedule check groups for, but it is difficult to track output. For that reason, it may be easier to test with `run_check_or_action` as described above. Below are examples from the Python interpreter with the example check group named `my_test_checks`.
 
 **NOTE:** if a check group has kwargs including `primary = True`, then the result will be written live to the Foursight UI. Omitting this argument when testing your check group may be desirable.
-
-**NOTE:** `run_check_group` is deprecated and can still be used because it is useful testing check groups. However, it cannot be used to test action groups.
 
 ```
 >>> import app
 # queue_check_group takes the environment name directly (not connection)
+# runs async; to see the results, see the Foursight UI, S3, or use Foursight API
 >>> app.queue_check_group('mastertest', 'my_test_checks')
-# once checks have run, you can check the foursight UI or endpoints for the results
-
-# create a Foursight connection to the 'mastertest' environment
->>> connection, _ = app.init_connection('mastertest')
-# the code below will return the results from the checks
->>> app.run_check_group(connection, 'my_test_checks')
 ```
 
 ### Manual testing of your action group
-Just like testing individual action functions is very similar to testing individual checks, testing action groups is almost the same as testing check groups. The only difference is you need to pass `use_action_group=True` into the `queue_check_group` function. Below is an example using the `patch_file_size` action group. **You cannot use run_check_group with action groups.**
+Just like testing individual action functions is very similar to testing individual checks, testing action groups is almost the same as testing check groups. The only difference is you need to pass `use_action_group=True` into the `queue_check_group` function. Below is an example using the `patch_file_size` action group.
 
 ```
 >>> import app

--- a/docs/development_tips.md
+++ b/docs/development_tips.md
@@ -34,10 +34,15 @@ Let's assume that you've already finished steps 1 through 4 in the list above (t
 >>> app.run_check_or_action(connection, 'wrangler_checks/items_created_in_the_past_day', {'item_type': 'File'})
 ```
 
-It's important to note that if you return the `check` at the end of your function, then the result will always get written to S3. To overwrite the "latest" check result, you must set the `primary = True` key word argument for your check. If you want to, you can pass this dictionary into the `run_check_or_action` function:
+It's important to note that if you return the `check` at the end of your function, then the result will always get written to S3. In this case, it is probably best to not overwrite the primary check result when testing (which is the one shown on the Foursight UI). Since running a check will always overwrite the `latest` result, you can test safely by omitting the `primary=True` key word argument and fetching those results with `get_latest_result` method of your check result.
+
+To overwrite the primary check result, you must set the `primary=True` key word argument for your check. If you want to, you can pass this dictionary into the `run_check_or_action` function:
 
 ```
-# will overwrite the latest result for items_created_in_the_past_day and display it on the UI
+# will overwrite the latest result for items_created_in_the_past_day, which won't display on the UI
+app.run_check_or_action(connection, 'wrangler_checks/items_created_in_the_past_day', {})
+
+# will overwrite the latest + primary results for items_created_in_the_past_day and display it on the UI
 app.run_check_or_action(connection, 'wrangler_checks/items_created_in_the_past_day', {'primary': True})
 ```
 
@@ -65,7 +70,7 @@ Actions function very similarly to checks when run individually. In fact, testin
 ### Manual testing of your check group
 Let's say you want to run a whole check group and not an individual check. To test this, you can use `app.queue_check_group`, which causes your checks to run synchronously. This function is the one that is internally used to schedule check groups for, but it is difficult to track output. For that reason, it may be easier to test with `run_check_or_action` as described above. Below are examples from the Python interpreter with the example check group named `my_test_checks`.
 
-**NOTE:** if a check group has kwargs including `primary = True`, then the result will be written live to the Foursight UI. Omitting this argument when testing your check group may be desirable.
+**NOTE:** if a check group has kwargs including `primary=True`, then the result will be written live to the Foursight UI. Omitting this argument when testing your check group may be desirable.
 
 ```
 >>> import app

--- a/docs/development_tips.md
+++ b/docs/development_tips.md
@@ -34,7 +34,14 @@ Let's assume that you've already finished steps 1 through 4 in the list above (t
 >>> app.run_check_or_action(connection, 'wrangler_checks/items_created_in_the_past_day', {'item_type': 'File'})
 ```
 
-It's important to note that if your check ends with the `check.store_result()` function, then the result will always get written to S3. If this is not desirable during your testing, either insert a break point before that function or omit it until testing is finished.
+It's important to note that if you return the `check` at the end of your function, then the result will always get written to S3. To overwrite the "latest" check result, you must set the `primary = True` key word argument for your check. If you want to, you can pass this dictionary into the `run_check_or_action` function:
+
+```
+# will overwrite the latest result for items_created_in_the_past_day and display it on the UI
+app.run_check_or_action(connection, 'wrangler_checks/items_created_in_the_past_day', {'primary': True})
+```
+
+ If writing any results to S3 is not desirable during your testing, either insert a break point before that function or not return the check result.
 
 
 ### Manual testing of your action
@@ -57,6 +64,8 @@ Actions function very similarly to checks when run individually. In fact, testin
 
 ### Manual testing of your check group
 Let's say you want to run a whole check group and not an individual check. There are two ways to test this: `app.run_check_group`, which will run your checks synchronously. Alternatively, you can use `app.queue_check_group`, which causes your checks to run synchronously. The first function is useful for testing but is limited by its speed and may actually timeout if the checks take too long to run. The second function is actually who scheduled check groups are run, but it is difficult to track output. Below are examples of both from the Python interpreter with the example check group named `my_test_checks`.
+
+**NOTE:** if a check group has kwargs including `primary = True`, then the result will be written live to the Foursight UI. Omitting this argument when testing your check group may be desirable.
 
 **NOTE:** `run_check_group` is deprecated and can still be used because it is useful testing check groups. However, it cannot be used to test action groups.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -59,7 +59,7 @@ def my_first_check(connection, **kwargs):
     return check
 ```
 
-Returning `check` at the end of the check causes the result of the check to be written to S3 with a unique key created by the check name and time the check was initiated. In addition, if a key word argument of `primary = True` is provided to your check, running it will overwrite the last "latest" check result, which is the one displayed from the Foursight front end. This is an important behavior of Foursight--the latest `primary = True` result is the one displayed.
+Returning `check` at the end of the check causes the result of the check to be written to S3 with a unique key created by the check name and time the check was initiated. In addition, if a key word argument of `primary=True` is provided to your check, running it will overwrite the last "latest" check result, which is the one displayed from the Foursight front end. This is an important behavior of Foursight--the latest `primary=True` result is the one displayed.
 
 There are many possibilities to what a check can do. Please visit the [writing checks documentation](./checks.md) for more information.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -35,7 +35,7 @@ def my_first_check(connection, **kwargs):
     # check status should be one of ['PASS', 'WARN', 'FAIL', 'ERROR', 'IGNORE']
     check.status = 'PASS'
     check.description = 'The first check I've ever made!'
-    check.store_result()
+    return check
 ```
 
 The first thing to note is each check *must* start with the `@check_function()` decorator. This allows Foursight to determine which functions are checks. In addition, any default key word arguments (kwargs) that you want to define for a check can be passed into the decorator as parameters (more on this later). Next, the check itself must take a `connection` parameter and `**kwargs`... the latter is not strictly necessary but should always be included as good form. Once adding the `@check_function()` decorator to a function, the function will be considered a check no matter what, and will be displayed on the Foursight front end.
@@ -56,15 +56,15 @@ def my_first_check(connection, **kwargs):
     else:
         check.status = 'PASS'
     check.description = 'The first check I've ever made!'
-    check.store_result()
+    return check
 ```
 
-Calling `check.store_result()` at the end of the check causes the result of the check to be written to S3 with a unique key created by the check name and time the check was initiated. In addition, each run of a check will overwrite the last "latest" check result, which is the one displayed from the Foursight front end. This is an important behavior of Foursight--the latest result is the one displayed.
+Returning `check` at the end of the check causes the result of the check to be written to S3 with a unique key created by the check name and time the check was initiated. In addition, if a key word argument of `primary = True` is provided to your check, running it will overwrite the last "latest" check result, which is the one displayed from the Foursight front end. This is an important behavior of Foursight--the latest `primary = True` result is the one displayed.
 
 There are many possibilities to what a check can do. Please visit the [writing checks documentation](./checks.md) for more information.
 
 ## Adding a check group
-Let's say we've created two check in the system_checks.py check module, named `my_first_check` and `my_second_check`. We also have a third check named `my_third_check` in wrangler_checks.py. To get these checks to run as a cohesive unit, we need to create a check group for them. This is done within the chalicelib.check_groups.py file. Each item in a check group is a list with three elements. The first element is a string (called a check string) in the form `<check_module>/<check_name>`, the second element is a dictionary of kwargs for the check, the third element is a list of dependencies ID strings that must be finished before the check runs, and the final element is the dependency ID for this check. The dependencies would be used in the case that we want to wait for one check to finish before running another. Let's say we want some kwargs passed into `my_first_check` and we want `my_third_check` to run after `my_second_check`. A check group would look like this, and are written as items in the CHECK_GROUPS dictionary in the check_groups.py file.
+Let's say we've created two check in the system_checks.py check module, named `my_first_check` and `my_second_check`. We also have a third check named `my_third_check` in wrangler_checks.py. To get these checks to run as a cohesive unit, we need to create a check group for them. This is done within the chalicelib.check_groups.py file. Each item in a check group is a list with three elements. The first element is a string (called a check string) in the form `<check_module>/<check_name>`, the second element is a dictionary of key word arguments (kwargs) for the check, the third element is a list of dependencies ID strings that must be finished before the check runs, and the final element is the dependency ID for this check. The dependencies would be used in the case that we want to wait for one check to finish before running another. Let's say we want some kwargs passed into `my_first_check` and we want `my_third_check` to run after `my_second_check`. A check group would look like this, and are written as items in the CHECK_GROUPS dictionary in the check_groups.py file.
 
 ```
 'my_test_checks': [

--- a/test.py
+++ b/test.py
@@ -664,16 +664,6 @@ class TestActionGroups(unittest.TestCase):
             # ensure action_group name matches an action in the group
             self.assertTrue(action_group in actions)
 
-        # for TEST_ACTION_GROUPS
-        for key, val in check_groups.TEST_ACTION_GROUPS.items():
-            self.assertTrue(isinstance(val, list))
-            for check_info in val:
-                self.assertTrue(len(check_info) == 4)
-                self.assertTrue(isinstance(check_info[0], app_utils.basestring))
-                self.assertTrue(isinstance(check_info[1], dict))
-                self.assertTrue(isinstance(check_info[2], list))
-                self.assertTrue(isinstance(check_info[3], app_utils.basestring))
-
 
 class TestUtils(unittest.TestCase):
     environ = 'mastertest' # hopefully this is up

--- a/test.py
+++ b/test.py
@@ -732,7 +732,7 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(action.name == 'test_action')
         self.assertTrue(action.s3_connection is not None)
 
-    def BadCheckOrAction(self):
+    def test_BadCheckOrAction(self):
         test_exc = utils.BadCheckOrAction()
         self.assertTrue(str(test_exc) == 'Check or action function seems to be malformed.')
         test_exc = utils.BadCheckOrAction('Abcd')

--- a/test.py
+++ b/test.py
@@ -90,20 +90,20 @@ class TestAppRoutes(unittest.TestCase):
         self.assertTrue('Currently logged in as admin.' in res.body)
 
     def test_run_foursight_checks(self):
-        res = app_utils.run_foursight_checks(self.environ, 'daily_checks')
+        res = app_utils.run_foursight_checks(self.environ, 'valid_test_checks')
         self.assertTrue(res.status_code == 200)
         self.assertTrue(set(res.body.keys()) == set(['status', 'environment', 'check_group']))
         self.assertTrue(res.body['environment'] == self.environ)
         self.assertTrue(res.body['status'] == 'success')
-        self.assertTrue(res.body['check_group'] == 'daily_checks')
+        self.assertTrue(res.body['check_group'] == 'valid_test_checks')
 
     def test_get_foursight_checks(self):
-        res = app_utils.get_foursight_checks(self.environ, 'daily_checks')
+        res = app_utils.get_foursight_checks(self.environ, 'valid_test_checks')
         self.assertTrue(res.status_code == 200)
         self.assertTrue(set(res.body.keys()) == set(['status', 'environment', 'checks', 'check_group']))
         self.assertTrue(res.body['environment'] == self.environ)
         self.assertTrue(res.body['status'] == 'success')
-        self.assertTrue(res.body['check_group'] == 'daily_checks')
+        self.assertTrue(res.body['check_group'] == 'valid_test_checks')
         self.assertTrue(isinstance(res.body['checks'], list) and len(res.body['checks']) > 0)
 
     def test_get_environment(self):
@@ -511,11 +511,11 @@ class TestCheckUtils(unittest.TestCase):
     def test_fetch_check_group(self):
         all_checks = check_utils.fetch_check_group('all_checks')
         self.assertTrue(isinstance(all_checks, list) and len(all_checks) > 0)
-        daily_checks = check_utils.fetch_check_group('daily_checks')
+        tm_checks = check_utils.fetch_check_group('ten_min_checks')
         # get list of check strings from lists of check info
-        daily_check_strs = [chk_str[0] for chk_str in daily_checks]
+        tm_checks_strs = [chk_str[0] for chk_str in tm_checks]
         all_check_strs = [chk_str[0] for chk_str in all_checks]
-        self.assertTrue(set(daily_check_strs) <= set(all_check_strs))
+        self.assertTrue(set(tm_checks_strs) <= set(all_check_strs))
         # make sure there are not duplicate check check names
         self.assertTrue(len(all_check_strs) == len(set(all_check_strs)))
         # non-existant check group

--- a/test.py
+++ b/test.py
@@ -438,6 +438,7 @@ class TestCheckResult(unittest.TestCase):
         check.description = 'This check is just for testing purposes.'
         check.status = 'PASS'
         check.full_output = ['first_item']
+        check.kwargs = {'primary': True}
         res = check.store_result()
         # fetch this check. latest and closest result with 0 diff should be the same
         late_res = check.get_latest_result()
@@ -699,13 +700,6 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(kwargs_add == {'abc': 123, 'bcd': 234})
         kwargs_override = self.test_function_dummy(abc=234)
         self.assertTrue(kwargs_override == {'abc': 234})
-
-    def test_build_dummy_result(self):
-        dummy_check = 'dumb_test'
-        dummy_res = utils.build_dummy_result(dummy_check)
-        self.assertTrue(dummy_res['status'] == 'IGNORE')
-        self.assertTrue(dummy_res['name']) == dummy_check
-        self.assertTrue('uuid' in dummy_res)
 
     def test_init_check_res(self):
         check = utils.init_check_res(self.conn, 'test_check', runnable=True)


### PR DESCRIPTION
Store kwargs in checks, display them on the Front end, remove `all` checks groups in favor of `all_checks`, and move the store_result logic to the check and action function decorators.