### PR TITLE
FF-1047

### DIFF
--- a/chalicelib/app_utils.py
+++ b/chalicelib/app_utils.py
@@ -275,7 +275,7 @@ def view_foursight(environ, is_admin=False, domain=""):
     for this_environ in view_envs:
         connection, error_res = init_connection(this_environ)
         if connection:
-            results = get_check_group_results(connection, 'all_checks')
+            results = get_check_group_results(connection, 'all')
             processed_results = []
             for res in results:
                 # first check to see if res is just a string, meaning

--- a/chalicelib/check_groups.py
+++ b/chalicelib/check_groups.py
@@ -43,7 +43,7 @@ ACTION_GROUPS = {
     ],
     'build_experiment_set_reports': [
         ['wrangler_checks/build_experiment_set_reports', {}, [], 'besr1'],
-        ['wrangler_checks/experiment_set_reporting', {}, ['besr1'], 'besr2']
+        ['wrangler_checks/experiment_set_reporting', {'primary': True}, ['besr1'], 'besr2']
     ]
 }
 

--- a/chalicelib/check_groups.py
+++ b/chalicelib/check_groups.py
@@ -42,7 +42,8 @@ ACTION_GROUPS = {
         ['wrangler_checks/identify_files_without_filesize', {'primary': True, 'search_add_on': '&datastore=database'}, ['pfs2'], 'pfs3']
     ],
     'build_experiment_set_reports': [
-        ['wrangler_checks/build_experiment_set_reports', {}, [], 'besr1']
+        ['wrangler_checks/build_experiment_set_reports', {}, [], 'besr1'],
+        ['wrangler_checks/experiment_set_reporting', {}, ['besr1'], 'besr2']
     ]
 }
 

--- a/chalicelib/check_groups.py
+++ b/chalicelib/check_groups.py
@@ -19,15 +19,15 @@ CHECK_GROUPS = {
         ['wrangler_checks/items_created_in_the_past_day', {'primary': True}, [], 'm10_2'],
         ['wrangler_checks/item_counts_by_type', {'primary': True}, [], 'm10_3'],
         ['wrangler_checks/change_in_item_counts', {'primary': True}, ['m10_3'], 'm10_4'],
-        ['wrangler_checks/replicate_file_reporting', {'primary': True}, [], 'm10_5'],
-        ['system_checks/indexing_progress', {'primary': True}, [], 'm10_6'],
-        ['system_checks/staging_deployment', {'primary': True}, [], 'm10_7']
+        ['system_checks/indexing_progress', {'primary': True}, [], 'm10_5'],
+        ['system_checks/staging_deployment', {'primary': True}, [], 'm10_6'],
+        ['wrangler_checks/experiment_set_reporting_data', {'primary': True}, [], 'm10_7'],
     ],
     'thirty_min_checks': [
-        ['wrangler_checks/files_associated_with_replicates', {'primary': True}, [],'m30_1'],
-        ['system_checks/status_of_elasticsearch_indices', {'primary': True}, [], 'm30_2'],
-        ['wrangler_checks/identify_files_without_filesize', {'primary': True}, [], 'm30_3'],
-        ['system_checks/indexing_records', {'primary': True}, [], 'm30_4']
+        ['system_checks/status_of_elasticsearch_indices', {'primary': True}, [], 'm30_1'],
+        ['wrangler_checks/identify_files_without_filesize', {'primary': True}, [], 'm30_2'],
+        ['system_checks/indexing_records', {'primary': True}, [], 'm30_2'],
+        ['wrangler_checks/experiment_set_reporting', {'primary': True}, [], 'm30_3'],
     ]
 }
 
@@ -40,6 +40,9 @@ ACTION_GROUPS = {
         ['wrangler_checks/identify_files_without_filesize', {'primary': True, 'search_add_on': '&datastore=database'}, [], 'pfs1'],
         ['wrangler_checks/patch_file_size', {}, ['pfs1'], 'pfs2'],
         ['wrangler_checks/identify_files_without_filesize', {'primary': True, 'search_add_on': '&datastore=database'}, ['pfs2'], 'pfs3']
+    ],
+    'build_experiment_set_reports': [
+        ['wrangler_checks/build_experiment_set_reports', {}, [], 'besr1']
     ]
 }
 
@@ -49,8 +52,6 @@ ACTION_GROUPS = {
 TEST_CHECK_GROUPS = {
     'all_checks': [
         ['wrangler_checks/items_created_in_the_past_day', {}, [], 'all1'],
-        ['wrangler_checks/files_associated_with_replicates', {}, [],'all2'],
-        ['wrangler_checks/replicate_file_reporting', {}, [], 'all3'],
         ['system_checks/elastic_beanstalk_health', {}, [], 'all4'],
         ['system_checks/status_of_elasticsearch_indices', {}, [], 'all5'],
         ['system_checks/indexing_records', {}, [], 'all6'],

--- a/chalicelib/check_groups.py
+++ b/chalicelib/check_groups.py
@@ -26,8 +26,8 @@ CHECK_GROUPS = {
     'thirty_min_checks': [
         ['system_checks/status_of_elasticsearch_indices', {'primary': True}, [], 'm30_1'],
         ['wrangler_checks/identify_files_without_filesize', {'primary': True}, [], 'm30_2'],
-        ['system_checks/indexing_records', {'primary': True}, [], 'm30_2'],
-        ['wrangler_checks/experiment_set_reporting', {'primary': True}, [], 'm30_3'],
+        ['system_checks/indexing_records', {'primary': True}, [], 'm30_3'],
+        ['wrangler_checks/experiment_set_reporting', {'primary': True}, [], 'm30_4'],
     ]
 }
 

--- a/chalicelib/check_utils.py
+++ b/chalicelib/check_utils.py
@@ -73,6 +73,7 @@ def get_check_group_results(connection, name, use_latest=False):
     sorted alphabetically
     By default, gets the 'primary' results. If use_latest is True, get the
     'latest' results instead.
+    Using name = 'all' will return all non-test check strings
     """
     latest_results = []
     check_group = fetch_check_group(name)
@@ -98,8 +99,11 @@ def get_check_group_results(connection, name, use_latest=False):
 def fetch_check_group(name):
     """
     Will be none if the group is not defined.
-    Special case for all_checks, which gets all checks and uses default kwargs
+    Special case for 'all', which gets all checks and uses default kwargs
     """
+    if name == 'all':
+        all_checks = get_check_strings()
+        return [[check_str, {}, [], ''] for check_str in all_checks]
     group = CHECK_GROUPS.get(name, None)
     # maybe it's a test groups
     if not group:

--- a/chalicelib/wrangler_checks.py
+++ b/chalicelib/wrangler_checks.py
@@ -273,7 +273,7 @@ def experiment_set_reporting(connection, **kwargs):
     if latest_action is None or latest_action['status'] != 'DONE':
         # the action has not run before
         # store action as a reference point but don't actually run
-        action.status = 'DONE'
+        action_result.status = 'DONE'
         action_result.output = {
             'last_data_used': latest_data_result['uuid'],
             'reports': []

--- a/chalicelib/wrangler_checks.py
+++ b/chalicelib/wrangler_checks.py
@@ -177,23 +177,25 @@ def experiment_set_reporting_data(connection, **kwargs):
         last_total = len(search_res)
         curr_from += last_total
         for exp_set in search_res:
-            exp_set_res = extract_info(exp_set, ['uuid', 'status'])
+            exp_set_res = extract_info(exp_set, ['@id', 'status','lab', 'award'])
+            exp_set_res['lab'] = exp_set_res['lab']['@id']
+            exp_set_res['award'] = exp_set_res['award']['@id']
             exp_set_res['processed_files'] = extract_list_info(
                 exp_set.get('processed_files'),
-                ['uuid', 'status', 'md5sum'],
+                ['@id', 'status', 'md5sum'],
                 'accession'
             )
             exps = {}
             for exp in exp_set.get('experiments_in_set', []):
-                exp_res = extract_info(exp, ['uuid', 'status', 'experiment_type'])
+                exp_res = extract_info(exp, ['@id', 'status'])
                 exp_res['files'] = extract_list_info(
                     exp.get('files'),
-                    ['uuid', 'status', 'md5sum'],
+                    ['@id', 'status', 'md5sum'],
                     'accession'
                 )
                 exp_res['processed_files'] = extract_list_info(
                     exp.get('processed_files'),
-                    ['uuid', 'status', 'md5sum'],
+                    ['@id', 'status', 'md5sum'],
                     'accession'
                 )
                 exps[exp['accession']] = exp_res
@@ -211,7 +213,53 @@ def experiment_set_reporting(connection, **kwargs):
     'build_experiment_set_reports' action.
     Stores the information used by that action to build reports.
     """
-    check = init_check_res(connection, 'experiment_set_reporting')
+    # helper function
+    def generate_report(curr_res, prev_res, field_path=[]):
+        """
+        Takes a dictionary current res and previous res and generates a report
+        from them. Fields looked at are in report_fields and it will also
+        recursively generate a report for all dictionary children that contain
+        a uuid and are in children_fields.
+        Returns None if there is no significant reporting; dict report otherwise.
+        """
+        significant_fields = {
+            'status': ['released', 'released_to_project'] # significant statuses
+        }
+        report_fields = ['status', 'md5sum']
+        include_fields = ['lab', 'award']
+        children_fields = ['experiments_in_set', 'files', 'processed_files']
+        this_report = {'changes': []}
+        for key, val in curr_res.items():
+            if key in children_fields and isinstance(val, dict):
+                for c_key, c_val in val.items():
+                    if isinstance(c_val, dict) and '@id' in c_val:
+                        prev_child = prev_res.get(key, {}).get(c_key, {})
+                        child_path = field_path + [key]
+                        child_report = generate_report(c_val, prev_child, child_path)
+                        if child_report:
+                            this_report['changes'].extend(child_report['changes'])
+            elif key in report_fields:
+                curr_val = curr_res.get(key)
+                prev_val = prev_res.get(key)
+                if key in significant_fields:
+                    significant = significant_fields[key]
+                    is_sig = curr_val in significant or prev_val in significant
+                else:
+                    # if this field is not in significant_fields, just see if changed
+                    is_sig = True
+                if is_sig and curr_val != prev_val:
+                    this_report['changes'].append({
+                        'field': '.'.join(field_path + [key]),
+                        'previous': prev_val,
+                        'current': curr_val,
+                        'item': curr_res['@id'],
+                        'reason': ' '.join([key, 'changed from', str(prev_val), 'to', str(curr_val)])
+                    })
+            elif key in include_fields:
+                this_report[key] = val
+        return this_report if this_report.get('changes') else None
+
+    check = init_check_res(connection, 'experiment_set_reporting', runnable=True)
     check.action = 'build_experiment_set_reports'
     # build reference to the check that provides data and get information
     data_check = init_check_res(connection, 'experiment_set_reporting_data')
@@ -220,7 +268,7 @@ def experiment_set_reporting(connection, **kwargs):
         check.status = 'ERROR'
         check.description = 'experiment_set_reporting_data results are not available.'
         return check
-    action_result = init_action_res('build_experiment_set_reports')
+    action_result = init_action_res(connection, 'build_experiment_set_reports')
     latest_action = action_result.get_latest_result()
     if latest_action is None or latest_action.get('output', {}).get('last_data_used') is None:
         # the action has not run before
@@ -243,95 +291,38 @@ def experiment_set_reporting(connection, **kwargs):
         check.description = 'experiment_set_reporting_data results are malformed.'
         return check
     reports = []
-    significant_statuses = ['released', 'released_to_project']
-    # assuming experiment sets will NOT be deleted from DB
-    ### CREATE REPORTS
-    # for exp_set in latest_output:
-    #     if latest_output
-    #     set_report = {}
-    #     if exp_set not in last_output:
-    #         set_report['summary'] = 'New experiment set %s was added' %
-
-    # only set check.allow_action if things look good with full_output
+    ### CREATE REPORTS... assuming experiment sets will NOT be deleted from DB
+    for exp_set in latest_output:
+        last_res = last_output.get(exp_set, {})
+        exp_set_report = generate_report(latest_output[exp_set], last_res)
+        if exp_set_report is not None:
+            reports.append(exp_set_report)
+    check.full_output = reports
+    if reports:
+        # store new reference report in admin_output
+        check.admin_output = latest_data_result['uuid']
+        check.status = 'WARN'
+        check.description = 'Ready to generate new experiment set reports.'
+        check.allow_action = True
+    else:
+        check.status = 'PASS'
+        check.description = 'There are no new experiment set reports.'
+    return check
 
 
 @action_function()
-def build_experiment_set_reports(connection **kwargs):
+def build_experiment_set_reports(connection, **kwargs):
     action = init_action_res(connection, 'build_experiment_set_reports')
     report_check = init_check_res(connection, 'experiment_set_reporting')
     report_output = report_check.get('full_output')
-    # do stuff with the report output (nothing for now)
-
-
-
-@check_function(delta_hours=24)
-def replicate_file_reporting(connection, **kwargs):
-    """
-    Meta check on files_associated_with_replicates. delta_hours is the diff
-    between the results for the aforementioned checks that we compare
-    """
-
-    def build_report(report, exp_set, latest_file, prior_file):
-        file_acc = latest_file.get('accession') if latest_file else prior_file.get('accession')
-        if not file_acc:
-            return
-        exp_acc = latest_file.get('exp_accession') if latest_file else prior_file.get('exp_accession')
-        latest_md5 = latest_file.get('md5sum')
-        prior_md5 = prior_file.get('md5sum')
-        latest_stat = latest_file.get('status')
-        prior_stat = prior_file.get('status')
-        if exp_acc:
-            file_str = ''.join(['File ', file_acc, ' of experiment ', exp_acc])
-        else:
-            file_str = ''.join(['File ', file_acc])
-        file_str_adds = []
-        if latest_file and not prior_file:
-            file_str_adds.append(' has been added')
-            if latest_stat in ['released', 'released to project']:
-                file_str_adds.append(''.join([' with status ', latest_stat]))
-        elif prior_file and not latest_file:
-            file_str_adds.append(' has been removed')
-        elif any(i in ['released', 'released to project'] for i in [latest_stat, prior_stat]):
-            # we only care about specifics if the file has been released
-            if latest_stat != prior_stat and latest_stat and prior_stat:
-                file_str_adds.append(''.join([' has status changed from ', prior_stat, ' to ', latest_stat]))
-            if latest_md5 != prior_md5 and latest_md5 and prior_md5:
-                file_str_adds.append(' has a changed md5sum')
-        if file_str_adds:
-            fin_str = file_str + ' and'.join(file_str_adds) + '.'
-            if exp_set in report:
-                report[exp_set].append(fin_str)
-            else:
-                report[exp_set] = [fin_str]
-
-    delta_hours = kwargs.get('delta_hours')
-    check = init_check_res(connection, 'replicate_file_reporting')
-    files_check = init_check_res(connection, 'files_associated_with_replicates')
-    latest_results = files_check.get_primary_result().get('full_output')
-    prior_results = files_check.get_closest_result(delta_hours).get('full_output')
-    if not isinstance(latest_results, dict) or not isinstance(prior_results, dict):
-        check.status = 'ERROR'
-        check.description = 'Could not generate report due to missing output of files_associated_with_replicates check.'
-        return check
-    report = {}
-    all_sets = list(set(latest_results.keys()).union(set(prior_results.keys())))
-    for exp_set in all_sets:
-        latest_file_accs = latest_results.get(exp_set, {}).keys()
-        prior_file_accs = prior_results.get(exp_set, {}).keys()
-        file_accs = list(set(latest_file_accs).union(set(prior_file_accs)))
-        for file_acc in file_accs:
-            latest_file = latest_results.get(exp_set, {}).get(file_acc, {})
-            prior_file = prior_results.get(exp_set, {}).get(file_acc, {})
-            # modifies report in place
-            build_report(report, exp_set, latest_file, prior_file)
-    check.full_output = report
-    if report:
-        check.status = 'WARN'
-        check.description = ''.join(['Significant file changes to one or more experiment sets have occured in the last ', str(delta_hours), ' hours.'])
-    else:
-        check.status = 'PASS'
-        check.description = ''.join(['No significant file changes to one or more experiment sets have occured in the last ', str(delta_hours), ' hours.'])
-    return check
+    report_reference = report_check.get('admin_output')
+    action.output = {
+        'last_data_used': report_reference,
+        'reports': report_output
+    }
+    if report_output:
+        action.status = 'PASS'
+    return action
 
 
 @check_function(search_add_on='&limit=all')

--- a/chalicelib/wrangler_checks.py
+++ b/chalicelib/wrangler_checks.py
@@ -112,7 +112,7 @@ def items_created_in_the_past_day(connection, **kwargs):
     # date string of approx. one day ago in form YYYY-MM-DD
     date_str = (datetime.datetime.utcnow() - datetime.timedelta(days=1)).strftime('%Y-%m-%d')
     search_query = ''.join(['/search/?type=', item_type, '&limit=all&q=date_created:>=', date_str])
-    search_res = ff_utils.get_metadata(search_query, connection=fdn_conn, frame='object')
+    search_res = ff_utils.search_metadata(search_query, connection=fdn_conn, frame='object')
     results = search_res.get('@graph', [])
     full_output = check.full_output if check.full_output else {}
     item_output = []
@@ -163,7 +163,7 @@ def files_associated_with_replicates(connection, **kwargs):
     while not total_replicates or curr_from < total_replicates:
         # sort by acession and grab 10 at a time to keep memory usage down
         search_query = ''.join(['/browse/?type=ExperimentSetReplicate&experimentset_type=replicate&from=', str(curr_from), '&limit=', str(limit), '&sort=accession'])
-        search_res = ff_utils.get_metadata(search_query, connection=fdn_conn, frame='embedded')
+        search_res = ff_utils.search_metadata(search_query, connection=fdn_conn, frame='embedded')
         if not total_replicates:
             total_replicates = search_res.get('total')
         results = search_res.get('@graph', [])
@@ -270,7 +270,7 @@ def identify_files_without_filesize(connection, **kwargs):
         check.description = ''.join(['Could not establish a FDN_Connection using the FF env: ', connection.ff_env])
         return check
     search_url = '/search/?type=File&status=released%20to%20project&status=released&status=uploaded' + kwargs.get('search_add_on', '')
-    search_res = ff_utils.get_metadata(search_url, connection=fdn_conn, frame='object')
+    search_res = ff_utils.search_metadata(search_url, connection=fdn_conn, frame='object')
     problem_files = []
     hits = search_res.get('@graph', [])
     for hit in hits:

--- a/chalicelib/wrangler_checks.py
+++ b/chalicelib/wrangler_checks.py
@@ -314,8 +314,9 @@ def experiment_set_reporting(connection, **kwargs):
 def build_experiment_set_reports(connection, **kwargs):
     action = init_action_res(connection, 'build_experiment_set_reports')
     report_check = init_check_res(connection, 'experiment_set_reporting')
-    report_output = report_check.get('full_output')
-    report_reference = report_check.get('admin_output')
+    report_result = report_check.get_primary_result()
+    report_output = report_result.get('full_output')
+    report_reference = report_result.get('admin_output')
     action.output = {
         'last_data_used': report_reference,
         'reports': report_output

--- a/chalicelib/wrangler_checks.py
+++ b/chalicelib/wrangler_checks.py
@@ -178,8 +178,8 @@ def experiment_set_reporting_data(connection, **kwargs):
         curr_from += last_total
         for exp_set in search_res:
             exp_set_res = extract_info(exp_set, ['@id', 'status','lab', 'award'])
-            exp_set_res['lab'] = exp_set_res['lab']['@id']
-            exp_set_res['award'] = exp_set_res['award']['@id']
+            exp_set_res['lab'] = exp_set_res.get('lab', {}).get('@id')
+            exp_set_res['award'] = exp_set_res.get('award', {}).get('@id')
             exp_set_res['processed_files'] = extract_list_info(
                 exp_set.get('processed_files'),
                 ['@id', 'status', 'md5sum'],

--- a/chalicelib/wrangler_checks.py
+++ b/chalicelib/wrangler_checks.py
@@ -270,9 +270,10 @@ def experiment_set_reporting(connection, **kwargs):
         return check
     action_result = init_action_res(connection, 'build_experiment_set_reports')
     latest_action = action_result.get_latest_result()
-    if latest_action is None or latest_action.get('output', {}).get('last_data_used') is None:
+    if latest_action is None or latest_action['status'] != 'DONE':
         # the action has not run before
         # store action as a reference point but don't actually run
+        action.status = 'DONE'
         action_result.output = {
             'last_data_used': latest_data_result['uuid'],
             'reports': []
@@ -321,8 +322,7 @@ def build_experiment_set_reports(connection, **kwargs):
         'last_data_used': report_reference,
         'reports': report_output
     }
-    if report_output:
-        action.status = 'PASS'
+    action.status = 'DONE'
     return action
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ PyJWT==1.5.3
 Jinja2==2.9.6
 chalice==1.1.0
 MarkupSafe==1.0
-dcicutils>=0.1.61
+dcicutils>=0.1.74

--- a/test.py
+++ b/test.py
@@ -624,7 +624,7 @@ class TestCheckUtils(FSTest):
         self.assertTrue(bad_act_str is None)
 
     def test_fetch_check_group(self):
-        all_checks = check_utils.fetch_check_group('all_checks')
+        all_checks = check_utils.fetch_check_group('all')
         self.assertTrue(isinstance(all_checks, list) and len(all_checks) > 0)
         tm_checks = check_utils.fetch_check_group('ten_min_checks')
         # get list of check strings from lists of check info
@@ -650,7 +650,7 @@ class TestCheckUtils(FSTest):
         # dict to compare uuids
         uuid_compares = {}
         # will get primary results by default
-        all_res_primary = check_utils.get_check_group_results(self.conn, 'all_checks')
+        all_res_primary = check_utils.get_check_group_results(self.conn, 'all')
         for check_res in all_res_primary:
             self.assertTrue(isinstance(check_res, dict))
             self.assertTrue('name' in check_res)
@@ -658,7 +658,7 @@ class TestCheckUtils(FSTest):
             self.assertTrue('uuid' in check_res)
             uuid_compares[check_res['name']] = check_res['uuid']
         # compare to latest results (which should be the same or newer)
-        all_res_latest = check_utils.get_check_group_results(self.conn, 'all_checks', use_latest=True)
+        all_res_latest = check_utils.get_check_group_results(self.conn, 'all', use_latest=True)
         for check_res in all_res_latest:
             self.assertTrue(isinstance(check_res, dict))
             self.assertTrue('name' in check_res)

--- a/test.py
+++ b/test.py
@@ -417,13 +417,13 @@ class TestCheckRunner(FSTest):
         finished_count = 0 # since queue attrs are approximate
         # wait for queue to empty
         while finished_count < 3:
-            time.sleep(3)
+            time.sleep(1)
             sqs_attrs = app_utils.get_sqs_attributes(self.queue.url)
             vis_messages = int(sqs_attrs.get('ApproximateNumberOfMessages'))
             invis_messages = int(sqs_attrs.get('ApproximateNumberOfMessagesNotVisible'))
             if vis_messages == 0 and invis_messages == 0:
                 finished_count += 1
-        time.sleep(3)
+        time.sleep(1)
         # look at output
         post_res = check.get_latest_result()
         self.assertTrue(prior_res['uuid'] != post_res['uuid'])
@@ -438,13 +438,13 @@ class TestCheckRunner(FSTest):
         finished_count = 0 # since queue attrs are approximate
         # wait for queue to empty
         while finished_count < 3:
-            time.sleep(3)
+            time.sleep(1)
             sqs_attrs = app_utils.get_sqs_attributes(self.queue.url)
             vis_messages = int(sqs_attrs.get('ApproximateNumberOfMessages'))
             invis_messages = int(sqs_attrs.get('ApproximateNumberOfMessagesNotVisible'))
             if vis_messages == 0 and invis_messages == 0:
                 finished_count += 1
-        time.sleep(3)
+        time.sleep(1)
         post_res = action.get_latest_result()
         self.assertTrue(prior_res['uuid'] != post_res['uuid'])
 
@@ -459,14 +459,14 @@ class TestCheckRunner(FSTest):
         finished_count = 0 # since queue attrs are approximate
         # wait for queue to empty
         while finished_count < 3:
-            time.sleep(3)
+            time.sleep(1)
             sqs_attrs = app_utils.get_sqs_attributes(run_input.get('sqs_url'))
             vis_messages = int(sqs_attrs.get('ApproximateNumberOfMessages'))
             invis_messages = int(sqs_attrs.get('ApproximateNumberOfMessagesNotVisible'))
             if vis_messages == 0 and invis_messages == 0:
                 finished_count += 1
         # queue should be empty. check results
-        time.sleep(3)
+        time.sleep(1)
         post_res = check_utils.get_check_group_results(self.connection, 'all_checks', use_latest=True)
         # compare the runtimes to ensure checks have run
         res_compare = {}
@@ -491,12 +491,12 @@ class TestCheckRunner(FSTest):
         self.assertTrue(vis_messages > 0 or invis_messages > 0)
         # wait for queue to empty
         while vis_messages > 0 or invis_messages > 0:
-            time.sleep(6)
+            time.sleep(1)
             sqs_attrs = app_utils.get_sqs_attributes(run_input.get('sqs_url'))
             vis_messages = int(sqs_attrs.get('ApproximateNumberOfMessages'))
             invis_messages = int(sqs_attrs.get('ApproximateNumberOfMessagesNotVisible'))
         # queue should be empty. check results
-        time.sleep(3)
+        time.sleep(1)
         post_res = action.get_latest_result()
         print_dict = {'prior': prior_res['uuid'], 'post': post_res['uuid']}
         # compare the uuids to ensure actions have run


### PR DESCRIPTION
Created experiment_set_reporting_data and experiment_set_reporting checks (removed the "replicate file reporting" checks). Also added the build_experiment_set_reports action. Taken together, these are the first step towards FF report generation.

Also, re-implemented 'all' as a valid arg for get_lastest_check_results... maintaining all_checks was getting annoying.