### PR TITLE
Help url check

### DIFF
--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -307,7 +307,7 @@
     },
     "check_help_page_urls": {
         "title": "Static Section URL check",
-        "group": "Metadata checks",
+        "group": "Audit checks",
         "schedule": {
             "morning_checks": {
                 "all": {

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -305,6 +305,18 @@
             }
         }
     },
+    "check_help_page_urls": {
+        "title": "Static Section URL check",
+        "group": "Metadata checks",
+        "schedule": {
+            "morning_checks": {
+                "all": {
+                    "kwargs": {"primary": true},
+                    "dependencies": []
+                }
+            }
+        }
+    },
     "workflow_run_has_deleted_input_file": {
         "title": "WorkflowRun linked to deleted Files",
         "group": "Metadata checks",

--- a/chalicelib/checks/audit_checks.py
+++ b/chalicelib/checks/audit_checks.py
@@ -6,6 +6,8 @@ from ..utils import (
     init_action_res
 )
 from dcicutils import ff_utils
+import re
+import requests
 
 
 def compare_badges(obj_ids, item_type, badge, ffenv):
@@ -667,4 +669,37 @@ def page_children_routes(connection, **kwargs):
         check.summary = 'No pages with bad routes'
         check.description = 'All routes of child pages are a direct sub-route of parent page'
     check.full_output = problem_routes
+    return check
+
+
+@check_function()
+def check_help_page_urls(connection, **kwargs):
+    check = init_check_res(connection, 'check_help_page_urls')
+
+    server = ff_utils.get_authentication_with_server(ff_env=connection.ff_env)['server']
+    results = ff_utils.search_metadata('search/?type=StaticSection&q=help&status!=draft&field=body',
+                                       ff_env=connection.ff_env)
+    sections_w_broken_links = {}
+    for result in results:
+        broken_links = []
+        urls = re.findall('[\(|\[|=]["]*(http[^\s\)\]]+|/[^\s\)\]]+)[\)|\]|"]', result.get('body', ''))
+        for url in urls:
+            if url.startswith('/'):
+                # fill in appropriate url
+                url = server + url
+            request = requests.get(url)
+            if request.status_code not in [200, 412]:
+                broken_links.append((url, request.status_code))
+        if broken_links:
+            sections_w_broken_links[result['@id']] = broken_links
+    if sections_w_broken_links:
+        check.status = 'WARN'
+        check.summary = 'Broken links found'
+        check.description = ('{} static sections currently have broken links.'
+                             ''.format(len(sections_w_broken_links.keys())))
+    else:
+        check.status = 'PASS'
+        check.summary = 'No broken links found'
+        check.description = check.summary
+    check.full_output = sections_w_broken_links
     return check

--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -6,7 +6,6 @@ from ..utils import (
     init_action_res
 )
 from dcicutils import ff_utils
-import re
 import requests
 import sys
 import json
@@ -474,36 +473,3 @@ def patch_file_size(connection, **kwargs):
     action.status = 'DONE'
     action.output = action_logs
     return action
-
-
-@check_function()
-def check_help_page_urls(connection, **kwargs):
-    check = init_check_res(connection, 'check_help_page_urls')
-
-    server = ff_utils.get_authentication_with_server(ff_env=connection.ff_env)['server']
-    results = ff_utils.search_metadata('search/?type=StaticSection&q=help&status!=draft&field=body',
-                                       ff_env=connection.ff_env)
-    sections_w_broken_links = {}
-    for result in results:
-        broken_links = []
-        urls = re.findall('[\(|\[|=]["]*(http[^\s\)\]]+|/[^\s\)\]]+)[\)|\]|"]', content)
-        for url in urls:
-            if url.startswith('/'):
-                # fill in appropriate url
-                url = server + url
-            request = requests.get(url)
-            if request.status_code not in [200, 412]:
-                broken_links.append((url, request.status_code))
-        if broken_links:
-            sections_w_broken_links[result['@id']] = broken_links
-    if sections_w_broken_links:
-        check.status = 'WARN'
-        check.summary = 'Broken links found'
-        check.description = ('{} static sections currently have broken links.'
-                             ''.format(len(sections_w_broken_links.keys())))
-    else:
-        check.status = 'PASS'
-        check.summary = 'No broken links found'
-        check.description = check.summary
-    check.full_output = sections_w_broken_links
-    return check

--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -6,6 +6,7 @@ from ..utils import (
     init_action_res
 )
 from dcicutils import ff_utils
+import re
 import requests
 import sys
 import json


### PR DESCRIPTION
Finds broken urls in help pages - I used this check to find 15 more broken links in FF today (but had to fix them manually)