### PR TITLE
Purge search res

### DIFF
--- a/.chalice/policy-dev.json
+++ b/.chalice/policy-dev.json
@@ -8,7 +8,8 @@
         "lambda:*",
         "sqs:*",
         "es:*",
-        "rds:*"
+        "rds:*",
+        "ec2:*"
       ],
       "Resource": [
         "*"

--- a/.chalice/policy-prod.json
+++ b/.chalice/policy-prod.json
@@ -8,7 +8,8 @@
         "lambda:*",
         "sqs:*",
         "es:*",
-        "rds:*"
+        "rds:*",
+        "ec2:*"
       ],
       "Resource": [
         "*"

--- a/chalicelib/app_utils.py
+++ b/chalicelib/app_utils.py
@@ -675,7 +675,7 @@ def queue_scheduled_checks(sched_environ, schedule_name):
             check_vals.extend(check_schedule.get(environ, []))
             send_sqs_messages(queue, environ, check_vals)
     runner_input = {'sqs_url': queue.url}
-    for n in range(2): # number of parallel runners to kick off
+    for n in range(4): # number of parallel runners to kick off
         invoke_check_runner(runner_input)
     return runner_input # for testing purposes
 

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -638,5 +638,17 @@
                 }
             }
         }
+    },
+    "check_long_running_ec2s": {
+        "title": "Check Long-Running EC2s",
+        "group": "System checks",
+        "schedule": {
+            "hourly_checks": {
+                "data": {
+                    "kwargs": {"primary": true},
+                    "dependencies": []
+                }
+            }
+        }
     }
 }

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -643,7 +643,7 @@
         "title": "Check Long-Running EC2s",
         "group": "System checks",
         "schedule": {
-            "hourly_checks": {
+            "morning_checks": {
                 "data": {
                     "kwargs": {"primary": true},
                     "dependencies": []

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -626,5 +626,17 @@
                 }
             }
         }
+    },
+    "purge_download_tracking_items": {
+        "title": "Purge Download Tracking Items",
+        "group": "Cleanup checks",
+        "schedule": {
+            "ten_min_checks": {
+                "data": {
+                    "kwargs": {"primary": true},
+                    "dependencies": []
+                }
+            }
+        }
     }
 }

--- a/chalicelib/checks/system_checks.py
+++ b/chalicelib/checks/system_checks.py
@@ -733,7 +733,7 @@ def check_long_running_ec2s(connection, **kwargs):
                     'state': state['Name'], 'name': inst_name,
                     'id': ec2_inst.get('InstanceId'),
                     'type': ec2_inst.get('InstanceType'),
-                    'date_created_utc': created.strftime('%Y-%m-%dT%H\:%M')
+                    'date_created_utc': created.strftime('%Y-%m-%dT%H:%M')
                 }
                 check.full_output.append(ec2_log)
                 if inst_warn:

--- a/chalicelib/checks/system_checks.py
+++ b/chalicelib/checks/system_checks.py
@@ -690,13 +690,12 @@ def purge_download_tracking_items(connection, **kwargs):
     return check
 
 
-@check_function(hours=72)
+@check_function()
 def check_long_running_ec2s(connection, **kwargs):
     """
-    Flag all ec2s that have been running for longer than given number of hours
-    in the kwargs. Fail if any contain any strings from `warn_names` in their
+    Flag all ec2s that have been running for longer than 1 week (WARN) or 2 weeks
+    (FAIL) if any contain any strings from `flag_names` in their
     names, or if they have no name.
-    TODO: Maybe add a kwarg for warn_name?
     """
     from ..utils import get_stage_info
     check = init_check_res(connection, 'check_long_running_ec2s')
@@ -705,44 +704,73 @@ def check_long_running_ec2s(connection, **kwargs):
         return check
 
     client = boto3.client('ec2')
-    # flag instances that contain any of warn_names and have been running
+    # flag instances that contain any of flag_names and have been running
     # longer than warn_time
-    warn_names = ['awsem']
+    flag_names = ['awsem']
     warn_time = (datetime.datetime.now(datetime.timezone.utc) -
-                 datetime.timedelta(hours=kwargs['hours']))
-    ec2_res = client.describe_instances(Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
+                 datetime.timedelta(days=7))
+    fail_time = (datetime.datetime.now(datetime.timezone.utc) -
+                 datetime.timedelta(days=14))
+    ec2_res = client.describe_instances(
+        Filters=[{'Name': 'instance-state-name', 'Values': ['running']}]
+    )
     check.full_output = []
-    check.brief_output = []
+    check.brief_output = {'one_week': [], 'two_weeks': []}
     for ec2_info in ec2_res.get('Reservations', []):
         instances = ec2_info.get('Instances', [])
         if not instances:
             continue
         # for multiple instance (?) just check if any of them require warnings
         for ec2_inst in instances:
-            inst_warn = False
             state = ec2_inst.get('State')
             created = ec2_inst.get('LaunchTime')
             if not state or not created:
                 continue
             inst_name = [kv['Value'] for kv in ec2_inst.get('Tags', [])
                          if kv['Key'] == 'Name']
-            if not inst_name or any([wn for wn in warn_names if wn in inst_name]):
-                inst_warn = True
-            if created < warn_time:
-                ec2_log = {
-                    'state': state['Name'], 'name': inst_name,
-                    'id': ec2_inst.get('InstanceId'),
-                    'type': ec2_inst.get('InstanceType'),
-                    'date_created_utc': created.strftime('%Y-%m-%dT%H:%M')
-                }
+            other_tags = {kv['Key']: kv['Value'] for kv in ec2_inst.get('Tags', [])
+                         if kv['Key'] != 'Name'}
+            ec2_log = {
+                'state': state['Name'], 'name': inst_name,
+                'id': ec2_inst.get('InstanceId'),
+                'type': ec2_inst.get('InstanceType'),
+                'date_created_utc': created.strftime('%Y-%m-%dT%H:%M')
+            }
+            if not inst_name:
+                flag_instance = True
+                # include all other tags if Name tag is empty
+                ec2_log['tags'] = other_tags
+            elif any([wn for wn in flag_names if wn in inst_name]):
+                flag_instance = True
+            else:
+                flag_instance = False
+            # always add record to full_output; add to brief_output if
+            # the instance is flagged based on 'Name' tag
+            if created < fail_time:
+                if flag_instance:
+                    check.brief_output['two_weeks'].append(ec2_log)
                 check.full_output.append(ec2_log)
-                if inst_warn:
-                    check.brief_output.append(ec2_log)
-    if check.brief_output:
-        check.status = 'FAIL'
-        check.summary = '%s suspect EC2 instances running longer than %s hours' % (len(check.brief_output), kwargs['hours'])
-        check.description = check.summary + '. Flagged because name is empty or contains %s. There are also %s non-flagged instances.' % (warn_names, len(check.full_output) - len(check.brief_output))
+            elif created < warn_time:
+                if flag_instance:
+                    check.brief_output['one_week'].append(ec2_log)
+                check.full_output.append(ec2_log)
+
+    if check.brief_output['one_week'] or check.brief_output['two_weeks']:
+        num_1wk = len(check.brief_output['one_week'])
+        num_2wk = len(check.brief_output['two_weeks'])
+        check.summary = ''
+        if check.brief_output['two_weeks']:
+            check.status = 'FAIL'
+            check.summary = '%s suspect EC2s running longer than 2 weeks' % num_2wk
+        if check.brief_output['one_week']:
+            if check.status != 'FAIL':
+                check.status = 'WARN'
+            if check.summary:
+                check.summary += ' and %s others longer than 1 week' % num_1wk
+            else:
+                check.summary = '%s suspect EC2s running longer than 1 week' % num_1wk
+        check.description = check.summary + '. Flagged because name is empty or contains %s. There are also %s non-flagged instances.' % (flag_names, len(check.full_output) - (num_1wk + num_2wk))
     else:
         check.status = 'PASS'
-        check.summary = '%s EC2 instances running longer than %s hours' % (len(check.full_output), kwargs['hours'])
+        check.summary = '%s EC2s running longer than 1 week' % (len(check.full_output))
     return check

--- a/chalicelib/checks/system_checks.py
+++ b/chalicelib/checks/system_checks.py
@@ -624,3 +624,13 @@ def process_download_tracking_items(connection, **kwargs):
     check.summary = 'Successfully processed %s download tracking items' % counts['proc']
     check.description = '%s. Released %s items and deleted %s items' % (check.summary, counts['released'], counts['deleted'])
     return check
+
+
+@check_function(
+    search='/search/?status=deleted&type=TrackingItem&tracking_type=download_tracking',
+    record_metadata=True
+)
+def purge_items_by_search(connection, **kwargs):
+    check = init_check_res(connection, 'purge_items_by_search')
+    search_res = ff_utils.search_metadata(kwargs['search'], key=connection.ff_keys,
+                                           ff_env=connection.ff_env, add_on='frame=object')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dcicutils>=0.5.4
+dcicutils>=0.6.2
 requests==2.20.0
 click==6.7
 PyJWT==1.5.3


### PR DESCRIPTION
This has already been deployed to prod.

Includes:
- **check_long_running_ec2s**. Flag ec2s that have been running over a given number of hours with certain names
- **purge_download_tracking_items**. Purge deleted download_tracking items
- **process_download_tracking_items**. Do not process tracking_items with `download_tracking.request_headers`. This is so we can check out the field before releasing