### PR TITLE
added opf status check to audit_checks

### DIFF
--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -261,6 +261,18 @@
             }
         }
     },
+    "check_opf_status_mismatch": {
+        "title": "Experiment Sets containing Other Processed Files with mismatched status",
+        "group": "Audit checks",
+        "schedule": {
+            "morning_checks": {
+                "all": {
+                    "kwargs": {"primary": true},
+                    "dependencies": []
+                }
+            }
+        }
+    },
     "check_validation_errors": {
         "title": "Search for Validation Errors",
         "group": "Audit checks",

--- a/chalicelib/checks/audit_checks.py
+++ b/chalicelib/checks/audit_checks.py
@@ -490,7 +490,7 @@ def check_opf_status_mismatch(connection, **kwargs):
             for exp in result['experiments_in_set']:
                 for case in exp['other_processed_files']:
                     files.extend([i['uuid'] for i in case['files']])
-    resp =  ff_utils.get_es_metadata(files, chunk_size=1000, ff_env=ffenv)
+    resp =  ff_utils.get_es_metadata(files, chunk_size=1000, ff_env=connection.ff_env)
     status_dict = {f['uuid']: f['properties']['status'] for f in resp}
     check.full_output = {}
     for result in results:


### PR DESCRIPTION
- checks if any files in a set of other_processed_files have mismatching statuses
- checks if a set of other_processed_files has a higher status than parent experiment_set