### PR TITLE
Pending users check

### DIFF
--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -760,7 +760,6 @@
         }
     },
     "md5run_status" : {
-
         "title": "md5run",
         "group": "Pipeline checks",
         "schedule": {
@@ -775,6 +774,18 @@
     "fastqc_status" : {
         "title": "fastqc",
         "group": "Pipeline checks",
+        "schedule": {
+            "morning_checks": {
+                "data": {
+                    "kwargs": {"primary": true},
+                    "dependencies": []
+                }
+            }
+        }
+    },
+    "users_with_pending_lab": {
+        "title": "Users with Pending Lab",
+        "group": "Metadata checks",
         "schedule": {
             "morning_checks": {
                 "data": {

--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -58,7 +58,6 @@ def workflow_run_has_deleted_input_file(connection, **kwargs):
 def patch_workflow_run_to_deleted(connection, **kwargs):
     action = init_action_res(connection, 'patch_workflow_run_to_deleted')
     action_logs = {'patch_failure': [], 'patch_success': []}
-    # get latest results
     wfr_w_del_check = init_check_res(connection, 'workflow_run_has_deleted_input_file')
     check_res = wfr_w_del_check.get_result_by_uuid(kwargs['called_by'])
     for wfruid in check_res['full_output']:
@@ -763,3 +762,76 @@ def validate_entrez_geneids(connection, **kwargs):
         check.status = "PASS"
         check.description = "GENE IDs are all valid"
     return check
+
+
+@check_function()
+def users_with_pending_lab(connection, **kwargs):
+    check = init_check_res(connection, 'users_with_pending_lab')
+    check.action = 'finalize_user_pending_labs'
+    check.full_output = []
+    check.status = 'PASS'
+    cached_items = {}  # store labs/PIs for performance
+    mismatch_users = []
+    # do not look for deleted/replaced users
+    search_q = '/search/?type=User&pending_lab!=No+value&frame=object'
+    search_res = ff_utils.search_metadata(search_q, key=connection.ff_keys, env=connection.ff_env)
+    for res in search_res:
+        user_fields = ['uuid', 'email', 'pending_lab', 'lab',
+                       'title', 'job_title']
+        user_append = {k: res.get(k) for k in []}
+        check.full_output.append(user_append)
+        # Fail if we have a pending lab and lab that do not match
+        if user_append['pending_lab'] != user_append['lab']:
+            check.status = 'FAIL'
+            mismatch_users.append(user_fields['uuid'])
+            continue
+        # cache the lab and PI contact info
+        if user_fields['pending_lab'] not in cached_items:
+            to_cache = {}
+            pending_meta = ff_utils.get_metadata(user_fields['pending_lab'], key=connection.ff_keys,
+                                                 env=connection.ff_env, add_on='frame=object')
+            to_cache['lab_title'] = pending_meta['display_title']
+            if 'pi' in pending_meta:
+                pi_meta = ff_utils.get_metadata(pending_meta['pi'], key=connection.ff_keys,
+                                                env=connection.ff_env, add_on='frame=object')
+                to_cache['lab_PI_email'] = pi_meta['email']
+                to_cache['lab_PI_title'] = pi_meta['title']
+            cached_items[user_fields['pending_lab']] = to_cache
+        # now use the cache to fill fields
+        for lab_field in ['lab_title', 'lab_PI_email', 'lab_PI_title']:
+            user_fields[lab_field] = cached_items[user_fields['pending_lab']].get(lab_field)
+
+    if check.full_output:
+        check.summary = 'Users found with pending_lab.'
+        if check.status == 'PASS':
+            check.status = 'WARN'
+            check.description = check.summary + '. Run the action to add lab and remove pending_lab'
+            check.allow_action = True
+            check.action_message = 'Will attempt to patch lab and remove pending_lab for %s users' % len(check.full_output)
+        if check.status = 'FAIL':
+            check.summary += '. Mismatches found for pending_lab and existing lab'
+            check.description = check.summary + '. Resolve conflicts for mismatching users before running action. See brief_output'
+            check.brief_output = mismatch_users
+    else:
+        check.summary = 'No users found with pending_lab'
+    return check
+
+
+@action_function()
+def finalize_user_pending_labs(connection, **kwargs):
+    action = init_action_res(connection, 'finalize_user_pending_labs')
+    pending_users_check = init_check_res(connection, 'users_with_pending_lab')
+    check_res = pending_users_check.get_result_by_uuid(kwargs['called_by'])
+    action.output = {'patch_failure': [], 'patch_success': []}
+    for user in check_res.get('full_output', []):
+        patch_data = {'lab': user['pending_lab']}
+        try:
+            ff_utils.patch_metadata(patch_data, obj_id=user['uuid'], key=connection.ff_keys,
+                                    ff_env=connection.ff_env, add_on='delete_fields=pending_lab')
+        except Exception as e:
+            action_logs['patch_failure'].append({user['uuid']: str(e)})
+        else:
+            action_logs['patch_success'].append(user['uuid'])
+    action.status = 'DONE'
+    action.output = action_logs
+    return action

--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -774,32 +774,31 @@ def users_with_pending_lab(connection, **kwargs):
     mismatch_users = []
     # do not look for deleted/replaced users
     search_q = '/search/?type=User&pending_lab!=No+value&frame=object'
-    search_res = ff_utils.search_metadata(search_q, key=connection.ff_keys, env=connection.ff_env)
+    search_res = ff_utils.search_metadata(search_q, key=connection.ff_keys, ff_env=connection.ff_env)
     for res in search_res:
-        user_fields = ['uuid', 'email', 'pending_lab', 'lab',
-                       'title', 'job_title']
-        user_append = {k: res.get(k) for k in []}
+        user_fields = ['uuid', 'email', 'pending_lab', 'lab', 'title', 'job_title']
+        user_append = {k: res.get(k) for k in user_fields}
         check.full_output.append(user_append)
         # Fail if we have a pending lab and lab that do not match
-        if user_append['pending_lab'] != user_append['lab']:
+        if user_append['lab'] and user_append['pending_lab'] != user_append['lab']:
             check.status = 'FAIL'
-            mismatch_users.append(user_fields['uuid'])
+            mismatch_users.append(user_append['uuid'])
             continue
         # cache the lab and PI contact info
-        if user_fields['pending_lab'] not in cached_items:
+        if user_append['pending_lab'] not in cached_items:
             to_cache = {}
-            pending_meta = ff_utils.get_metadata(user_fields['pending_lab'], key=connection.ff_keys,
-                                                 env=connection.ff_env, add_on='frame=object')
+            pending_meta = ff_utils.get_metadata(user_append['pending_lab'], key=connection.ff_keys,
+                                                 ff_env=connection.ff_env, add_on='frame=object')
             to_cache['lab_title'] = pending_meta['display_title']
             if 'pi' in pending_meta:
                 pi_meta = ff_utils.get_metadata(pending_meta['pi'], key=connection.ff_keys,
-                                                env=connection.ff_env, add_on='frame=object')
+                                                ff_env=connection.ff_env, add_on='frame=object')
                 to_cache['lab_PI_email'] = pi_meta['email']
                 to_cache['lab_PI_title'] = pi_meta['title']
-            cached_items[user_fields['pending_lab']] = to_cache
+            cached_items[user_append['pending_lab']] = to_cache
         # now use the cache to fill fields
         for lab_field in ['lab_title', 'lab_PI_email', 'lab_PI_title']:
-            user_fields[lab_field] = cached_items[user_fields['pending_lab']].get(lab_field)
+            user_append[lab_field] = cached_items[user_append['pending_lab']].get(lab_field)
 
     if check.full_output:
         check.summary = 'Users found with pending_lab.'
@@ -808,7 +807,7 @@ def users_with_pending_lab(connection, **kwargs):
             check.description = check.summary + '. Run the action to add lab and remove pending_lab'
             check.allow_action = True
             check.action_message = 'Will attempt to patch lab and remove pending_lab for %s users' % len(check.full_output)
-        if check.status = 'FAIL':
+        if check.status == 'FAIL':
             check.summary += '. Mismatches found for pending_lab and existing lab'
             check.description = check.summary + '. Resolve conflicts for mismatching users before running action. See brief_output'
             check.brief_output = mismatch_users
@@ -825,6 +824,7 @@ def finalize_user_pending_labs(connection, **kwargs):
     action.output = {'patch_failure': [], 'patch_success': []}
     for user in check_res.get('full_output', []):
         patch_data = {'lab': user['pending_lab']}
+        # patch lab and delete pending_lab in one request
         try:
             ff_utils.patch_metadata(patch_data, obj_id=user['uuid'], key=connection.ff_keys,
                                     ff_env=connection.ff_env, add_on='delete_fields=pending_lab')


### PR DESCRIPTION
Made the `users_with_pending_lab` check and corresponding `finalize_user_pending_labs` action, both within wrangler_checks.py.

This check will find all users with `pending_lab` and record information about them, including user info and lab/PI info. This will hopefully make it easy to confirm with the lab PI that the user is legitimate. If the user has a `pending_lab` AND a `lab` that don't match, the check will fail.

The action sets `lab` to the value of `pending_lab` and deletes `pending_lab`. This will run on all users processed by the check, so ensure that every user from the check output is legitimate before running. Alternatively, it is easy to patch specific users by hand and then re-run the check. 