### PR TITLE
higlass_processed_fix: Removed unneeded Processed file field.

### DIFF
--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -839,9 +839,11 @@ def check_expsets_otherprocessedfiles_for_higlass_viewconf(connection, **kwargs)
         if filegroups_to_update:
             filegroups_info = expset.get("other_processed_files", [])
 
+            contributing_labs = [ c["uuid"] for c in expset.get("contributing_labs", []) ]
+
             expsets_to_update[accession] = {
                 "award" : expset["award"]["uuid"],
-                "contributing_labs": expset.get("contributing_labs", []),
+                "contributing_labs": contributing_labs,
                 "lab" : expset["lab"]["uuid"],
                 "description" : expset["description"],
                 "other_processed_files" : filegroups_info,

--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -511,7 +511,6 @@ def check_expsets_processedfiles_for_higlass_viewconf(connection, **kwargs):
             "files" : file_info["files"],
             "lab" : expset["lab"]["uuid"],
             "static_content" : expset.get("static_content", []),
-            "status" : expset["status"],
         }
         higlass_count += 1
         expset_count += 1


### PR DESCRIPTION
ExpSet Processed Files:
Removing a field that isn't needed in the Processed Files check. That line produces KeyErrors when the check tries to search for records.

ExpSet Other Processed Files:
Contributing labs needed to be reduced to just the uuid.