### PR TITLE
higlass_opf_fix: Not every opf group has a Higlass item.

### DIFF
--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -995,7 +995,7 @@ def patch_expsets_otherprocessedfiles_for_higlass_viewconf(connection, **kwargs)
         # The other_processed_files section has been updated. Patch the changes.
         try:
             # Make sure all higlass_view_config fields just show the uuid.
-            for g in expsets_to_update[accession]["other_processed_files"]:
+            for g in [ group for group in expsets_to_update[accession]["other_processed_files"] if "higlass_view_config" in group ]:
                 if isinstance(g["higlass_view_config"], dict):
                     uuid = g["higlass_view_config"]["uuid"]
                     g["higlass_view_config"] = uuid


### PR DESCRIPTION
The Other Processed Files check has to reduce any existing higlass_view_config section to just the uuid. The code assumed every group would have a uuid, but now it will skip groups that don't have them.