### PR TITLE
Higlass processed file combine

### DIFF
--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -224,6 +224,9 @@ def check_files_for_higlass_viewconf(connection, **kwargs):
         "target_files" : {},
     }
 
+    # Checks expire after 280 seconds, so keep track of how long this task has lasted.
+    start_time = time.time()
+
     # first, find and cache the reference files
     reference_files_by_ga = get_reference_files(connection)
     check_full_output['reference_files'] = reference_files_by_ga
@@ -305,7 +308,7 @@ def check_files_for_higlass_viewconf(connection, **kwargs):
         check.status = 'PASS'
     elif kwargs["check_only"] == False:
         # Pass check to action
-        action_result = patch_files_for_higlass_viewconf(connection, check_full_output, time.time(), kwargs['file_accession'])
+        action_result = patch_files_for_higlass_viewconf(connection, check_full_output, start_time, kwargs['file_accession'])
 
         check.description = check.summary = "Created Higlass viewconfs for {completed} out of {possible} files".format(
             completed=action_result["number_files_created"],
@@ -314,7 +317,7 @@ def check_files_for_higlass_viewconf(connection, **kwargs):
 
         check.status = "WARN"
         if action_result["number_files_created"] >= action_result["total_files"]:
-            check.status = "DONE"
+            check.status = "PASS"
 
         check.full_output = action_result["logs"]
     else:

--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -305,7 +305,7 @@ def check_files_for_higlass_viewconf(connection, **kwargs):
         check.status = 'PASS'
     elif kwargs["check_only"] == False:
         # Pass check to action
-        action_result = patch_files_for_higlass_viewconf(connection, check_full_output, kwargs['file_accession'])
+        action_result = patch_files_for_higlass_viewconf(connection, check_full_output, time.time(), kwargs['file_accession'])
 
         check.description = check.summary = "Created Higlass viewconfs for {completed} out of {possible} files".format(
             completed=action_result["number_files_created"],
@@ -326,13 +326,14 @@ def check_files_for_higlass_viewconf(connection, **kwargs):
         check.status = 'WARN'
     return check
 
-def patch_files_for_higlass_viewconf(connection, check_full_output, file_accession_to_patch=None):
+def patch_files_for_higlass_viewconf(connection, check_full_output, start_time=None, file_accession_to_patch=None):
     """ Action that is used with generate_higlass_view_confs_files to actually
     POST new higlass view configs and PATCH the old files.
 
     Args:
         connection: The connection to Fourfront.
         check_full_output (dict): The results of the check.
+        start_time (number, optional, default=None): Time since the check started. This function stops before foursight times it out.
         file_accession(string, optional, default=None): Only generate a viewconf for the given file acccession.
 
     Returns:
@@ -353,7 +354,8 @@ def patch_files_for_higlass_viewconf(connection, check_full_output, file_accessi
     ref_files_by_ga = check_full_output.get('reference_files', {})
 
     # Checks expire after 280 seconds, so keep track of how long this task has lasted.
-    start_time = time.time()
+    if not start_time:
+        start_time = time.time()
     time_expired = False
 
     # these are the files we care about

--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -363,7 +363,10 @@ def patch_files_for_higlass_viewconf(connection, check_full_output, file_accessi
         if time_expired:
             break
 
-        if ga not in ref_files_by_ga:  # reference files not found
+        if ga not in ref_files_by_ga:
+            # Note that we couldn't find the reference files.
+            for file_accession in target_files_by_ga[ga]:
+                action_logs['failed_to_create_viewconf'][file_accession] = "No reference files found for {ga}.".format(ga=ga)
             continue
 
         ref_files = ref_files_by_ga[ga]
@@ -578,7 +581,11 @@ def patch_expsets_processedfiles_for_higlass_viewconf(connection, **kwargs):
         if time_expired:
             break
 
-        if ga not in ref_files_by_ga:
+        #if ga not in ref_files_by_ga:
+        if True:
+            # Note that we couldn't find the reference files.
+            for expset_accession in target_files[ga]:
+                action_logs['failed_to_create_viewconf'][expset_accession] = "No reference files found for {ga}.".format(ga=ga)
             continue
         ref_files = ref_files_by_ga[ga]
 
@@ -941,6 +948,11 @@ def patch_expsets_otherprocessedfiles_for_higlass_viewconf(connection, **kwargs)
                 break
 
             # Get the reference files for the genome assembly
+            if info["genome_assembly"] not in ref_files_by_ga:
+                # Note that we couldn't find the reference files.
+                action_logs['failed_to_create_viewconf'][accession] = "No reference files found for {ga}.".format(ga=info["genome_assembly"])
+                continue
+
             reference_files = ref_files_by_ga[ info["genome_assembly"] ]
 
             # Create the Higlass Viewconf and get the uuid


### PR DESCRIPTION
This task will combine the check and action for generating Higlass displays for files.
- Adding check_only flag so this will not create new Higlass displays.
- Fixing bug where every file had to have contributing labs.
- If the reference files are missing, we won't try to make a Higlass viewconf.