### PR TITLE
Biofeat org chk

### DIFF
--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -201,6 +201,18 @@
             }
         }
     },
+    "check_bio_feature_organism_name": {
+        "title": "BioFeatures with missing or mismatched check_bio_feature_organism_name",
+        "group": "Audit checks",
+        "schedule": {
+            "morning_checks": {
+                "all": {
+                    "kwargs": {"primary": true},
+                    "dependencies": []
+                }
+            }
+        }
+    },
     "paired_end_info_consistent": {
         "title": "Fastq files with inconsistent paired end information",
         "group": "Audit checks",

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -202,7 +202,7 @@
         }
     },
     "check_bio_feature_organism_name": {
-        "title": "BioFeatures with missing or mismatched check_bio_feature_organism_name",
+        "title": "BioFeatures with missing or mismatched organism_name",
         "group": "Audit checks",
         "schedule": {
             "morning_checks": {

--- a/chalicelib/checks/audit_checks.py
+++ b/chalicelib/checks/audit_checks.py
@@ -663,6 +663,10 @@ def check_bio_feature_organism_name(connection, **kwargs):
                     if linked_orgn_name == 'unspecified':
                         name_trumps_guess += 1
                         to_report['name_trumps_guess'].update({bfuuid: (orgn_name, linked_orgn_name)})
+                    elif orgn_name == 'unspecified':  # patch if a specific name is found
+                        to_patch[bfuuid] = {'organism_name': linked_orgn_name}
+                        to_report['mismatches'].update({bfuuid: (orgn_name, linked_orgn_name)})
+                        brief_report.append('{}: CURRENT {} GUESS {} - WILL PATCH!'.format(bfname, orgn_name, linked_orgn_name))
                     else:
                         mismatches += 1
                         to_report['mismatches'].update({bfuuid: (orgn_name, linked_orgn_name)})

--- a/chalicelib/checks/audit_checks.py
+++ b/chalicelib/checks/audit_checks.py
@@ -599,7 +599,7 @@ def check_bio_feature_organism_name(connection, **kwargs):
     genome2orgn = {o.get('genome_assembly'): o.get('@id') for o in organisms if 'genome_assembly' in o}
     gene_search = 'search/?type=Gene'
     genes = ff_utils.search_metadata(gene_search, ff_env=connection.ff_env)
-    gene2org = {g.get('@id'): g.get('organism.@id') for g in genes}
+    gene2org = {g.get('@id'): g.get('organism').get('@id') for g in genes}
     # get all BioFeatures
     biofeat_search = 'search/?type=BioFeature'
     biofeatures = ff_utils.search_metadata(biofeat_search, ff_env=connection.ff_env)
@@ -617,7 +617,7 @@ def check_bio_feature_organism_name(connection, **kwargs):
                 for genreg in gen_regions:
                     assembly_in_dt = False
                     gr_dt = genreg.get('display_title')
-                    for ga, orgn in genome2orgn:
+                    for ga, orgn in genome2orgn.items():
                         if ga in gr_dt:
                             grorgns.append(orgn)
                             assembly_in_dt = True
@@ -629,7 +629,7 @@ def check_bio_feature_organism_name(connection, **kwargs):
                         except AttributeError:
                             gr_ass = None
                         if gr_ass is not None:
-                            for ga, orgn in genome2orgn:
+                            for ga, orgn in genome2orgn.items():
                                 if ga == gr_ass:
                                     grorgns.append(orgn)
                 linked_orgn_name = _get_orgname_from_atid_list(grorgns, orgn2name)


### PR DESCRIPTION
Audit check to find BioFeatures that:

- lack organism_name - tries to guess the appropriate value

- have mismatched organism_name 
       * if the assigned name is less specific that the guess patch it
       * if the assigned name is more specific than the guess just increments a count
       * if it looks like a true mismatch report it
      

Action will patch automatically only those cases where name was lacking or less specific than guessed name.