### PR TITLE
higlass_check_update: Fixed false positives, manual checks

### DIFF
--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -704,7 +704,7 @@
         }
     },
     "check_higlass_items_for_new_files": {
-        "title": "Create new Higlass Items for Files",
+        "title": "Create new Items for Files",
         "group": "Higlass checks",
         "schedule": {
             "hourly_checks": {
@@ -724,7 +724,7 @@
         }
     },
     "check_higlass_items_for_modified_files": {
-        "title": "Update Higlass Items for modified Files",
+        "title": "Update Items for modified Files",
         "group": "Higlass checks",
         "schedule": {
             "hourly_checks_2": {
@@ -744,13 +744,13 @@
         }
     },
     "check_higlass_items_for_queried_files": {
-        "title": "Manually update Higlass Items for Files",
+        "title": "Manually update Items for Files",
         "group": "Higlass checks",
         "schedule": {},
         "display": ["data", "hotseat", "webdev"]
     },
     "check_expsets_processedfiles_for_new_higlass_items": {
-        "title": "Create Higlass Items for Processed Files in modified Experiment Sets",
+        "title": "Create new Items for ExpSets (Processed Files)",
         "group": "Higlass checks",
         "schedule": {
             "hourly_checks": {
@@ -770,7 +770,7 @@
         }
     },
     "check_expsets_processedfiles_for_modified_higlass_items": {
-        "title": "Update Higlass Items for Processed Files in modified Experiment Sets",
+        "title": "Update existing Items for ExpSets (Processed Files)",
         "group": "Higlass checks",
         "schedule": {
             "hourly_checks_2": {
@@ -790,13 +790,13 @@
         }
     },
     "check_expsets_processedfiles_for_queried_higlass_items": {
-        "title": "Manually update Higlass Items for Processed Files in Experiment Sets",
+        "title": "Manually update for ExpSets (Processed Files)",
         "group": "Higlass checks",
         "schedule": {},
         "display": ["data", "webdev", "hotseat"]
     },
     "check_expsets_otherprocessedfiles_for_new_higlass_items": {
-        "title": "Create Higlass Items for Other Processed (aka Supplementary) Files in Experiment Sets",
+        "title": "Create/Update Items for ExpSets (Supplementary Files)",
         "group": "Higlass checks",
         "schedule": {
             "morning_checks": {
@@ -816,7 +816,7 @@
         }
     },
     "check_expsets_otherprocessedfiles_for_queried_files": {
-        "title": "Manually update Higlass Items for Other Processed (aka Supplementary) Files in Experiment Sets",
+        "title": "Manually update Items for ExpSets (Supplementary Files)",
         "group": "Higlass checks",
         "schedule": {},
         "display": ["data", "webdev", "hotseat"]

--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -353,8 +353,8 @@ def find_files_requiring_higlass_items(connection, check_name, action_name, sear
 
     # If no search query was provided, fail
     if not search_queries:
-        check.summary = check.description = "Search queries must be provided."
-        check.status = 'FAIL'
+        check.summary = check.description = "No search query provided, nothing to update."
+        check.status = 'PASS'
         check.allow_action = False
         return check
 
@@ -816,8 +816,8 @@ def find_expsets_processedfiles_requiring_higlass_items(connection, check_name, 
 
     # If no search query was provided, fail
     if not search_queries:
-        check.summary = check.description = "Search queries must be provided."
-        check.status = 'FAIL'
+        check.summary = check.description = "No search query provided, nothing to update."
+        check.status = 'PASS'
         check.allow_action = False
         return check
 
@@ -1164,10 +1164,10 @@ def find_expsets_otherprocessedfiles_requiring_higlass_items(connection, check_n
     check.queries = []
     check.action = action_name
 
-    # If no search query was provided and find_opfs_missing_higlass is False, fail
+    # If no search query was provided and find_opfs_missing_higlass is False, pass with no results
     if not (search_queries or find_opfs_missing_higlass):
-        check.summary = check.description = "If find_opfs_missing_higlass is false, Search queries must be provided."
-        check.status = 'FAIL'
+        check.summary = check.description = "No search query provided, nothing to update."
+        check.status = 'PASS'
         check.allow_action = False
         return check
 
@@ -1242,8 +1242,8 @@ def find_expsets_otherprocessedfiles_requiring_higlass_items(connection, check_n
                     if not higlass_modified_date:
                         return True
 
-                    # If the Higlass Item is older than the ExpSet, it should be considered.
-                    if higlass_modified_date < expset_last_modified_date:
+                    # If the Higlass Item is older than the ExpSet, it should be considered. Give about 10 minutes of leeway.
+                    if higlass_modified_date + timedelta(minutes=10) < expset_last_modified_date:
                         return True
                 else:
                     # If the ExpSet is new, then consider this group.

--- a/chalicelib/utils.py
+++ b/chalicelib/utils.py
@@ -168,7 +168,7 @@ def action_function(*default_args, **default_kwargs):
             signal.alarm(CHECK_TIMEOUT)  # run time allowed in seconds
             try:
                 if 'check_name' not in kwargs or 'called_by' not in kwargs:
-                    raise BadCheckOrAction('Action is missing check_name or called_by in its kwargs.')
+                    raise BadCheckOrAction('Action requires check_name and called_by in its kwargs.')
                 action = func(*args, **kwargs)
                 validate_run_result(action, is_check=False)
             except Exception as e:

--- a/chalicelib/utils.py
+++ b/chalicelib/utils.py
@@ -168,7 +168,7 @@ def action_function(*default_args, **default_kwargs):
             signal.alarm(CHECK_TIMEOUT)  # run time allowed in seconds
             try:
                 if 'check_name' not in kwargs or 'called_by' not in kwargs:
-                    raise BadCheckOrAction('Action is missing check_name/called_by in its kwargs.')
+                    raise BadCheckOrAction('Action is missing check_name or called_by in its kwargs.')
                 action = func(*args, **kwargs)
                 validate_run_result(action, is_check=False)
             except Exception as e:

--- a/chalicelib/utils.py
+++ b/chalicelib/utils.py
@@ -168,7 +168,7 @@ def action_function(*default_args, **default_kwargs):
             signal.alarm(CHECK_TIMEOUT)  # run time allowed in seconds
             try:
                 if 'check_name' not in kwargs or 'called_by' not in kwargs:
-                    raise BadCheckOrAction('Action is missing check_name or called_by in its kwargs.')
+                    raise BadCheckOrAction('Action is missing check_name and called_by in its kwargs.')
                 action = func(*args, **kwargs)
                 validate_run_result(action, is_check=False)
             except Exception as e:

--- a/chalicelib/utils.py
+++ b/chalicelib/utils.py
@@ -168,7 +168,7 @@ def action_function(*default_args, **default_kwargs):
             signal.alarm(CHECK_TIMEOUT)  # run time allowed in seconds
             try:
                 if 'check_name' not in kwargs or 'called_by' not in kwargs:
-                    raise BadCheckOrAction('Action is missing check_name and called_by in its kwargs.')
+                    raise BadCheckOrAction('Action is missing check_name or called_by in its kwargs.')
                 action = func(*args, **kwargs)
                 validate_run_result(action, is_check=False)
             except Exception as e:

--- a/test.py
+++ b/test.py
@@ -1091,7 +1091,7 @@ class TestCheckUtils(FSTest):
         action_res = check_utils.run_check_or_action(self.connection, 'test_checks/test_action_error', {})
         self.assertTrue(action_res['status'] == 'FAIL')
         # this output is a list
-        self.assertTrue('Action is missing check_name or called_by in its kwargs' in ''.join(action_res['output']))
+        self.assertTrue('Action requires check_name and called_by in its kwargs' in ''.join(action_res['output']))
         self.assertTrue(action_res['description'] == 'Action failed to run. See output.')
 
     def test_run_action_exception(self):

--- a/test.py
+++ b/test.py
@@ -1091,7 +1091,7 @@ class TestCheckUtils(FSTest):
         action_res = check_utils.run_check_or_action(self.connection, 'test_checks/test_action_error', {})
         self.assertTrue(action_res['status'] == 'FAIL')
         # this output is a list
-        self.assertTrue('Action is missing check_name and called_by in its kwargs' in ''.join(action_res['output']))
+        self.assertTrue('Action is missing check_name or called_by in its kwargs' in ''.join(action_res['output']))
         self.assertTrue(action_res['description'] == 'Action failed to run. See output.')
 
     def test_run_action_exception(self):

--- a/test.py
+++ b/test.py
@@ -1091,7 +1091,7 @@ class TestCheckUtils(FSTest):
         action_res = check_utils.run_check_or_action(self.connection, 'test_checks/test_action_error', {})
         self.assertTrue(action_res['status'] == 'FAIL')
         # this output is a list
-        self.assertTrue('Action is missing check_name/called_by in its kwargs' in ''.join(action_res['output']))
+        self.assertTrue('Action is missing check_name and called_by in its kwargs' in ''.join(action_res['output']))
         self.assertTrue(action_res['description'] == 'Action failed to run. See output.')
 
     def test_run_action_exception(self):


### PR DESCRIPTION
A few more issues to clean up on foursight after pushing https://github.com/4dn-dcic/foursight/pull/125 to master:

### Higlass check changes
- Higlass checks are considered PASS when no queries are added. This is to prevent manual queries from hitting every file, and an easy way to mark the manual checks as PASS rather than FAIL.
- For Supplementary files, we compare the Higlass Item modified date to the expset modified date to see if the HIglass Items need updating. With this task we add a 10 minute buffer. This avoids situations where the Higlass Items were updated right before the ExpSet.
- ExpSet Processed Files were unable to find the static_content.description field because of changes to the embedded list, so too many ExpSets were marked for updates. https://github.com/4dn-dcic/fourfront/pull/1084 fixes this issue and no changes are needed here.

### Simplify foursight check names
When you viewing them on the foursight page, it's a real mouthful. It's also not clear which one is for new files/ExpSets and which is for recently modified ones.
### Minor error message update