### PR TITLE
Register Higlass 

### DIFF
--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -528,7 +528,6 @@ def create_higlass_items_for_files(connection, check_name, action_name, called_b
                 files={
                     "reference":ref_files,
                     "content":[file_info],
-                    "height": 600,
                 },
                 higlass_item={
                     "uuid":existing_higlass_uuid,
@@ -999,7 +998,6 @@ def update_expsets_processedfiles_requiring_higlass_items(connection, check_name
                 files={
                     "reference":ref_files,
                     "content":files_for_viewconf,
-                    "height": max(300, 40 * len(files_for_viewconf)),
                 },
                 higlass_item={
                     "uuid": existing_higlass_uuid,
@@ -1459,7 +1457,6 @@ def update_expsets_otherprocessedfiles_for_higlass_items(connection, check_name,
                 files={
                     "reference": reference_files,
                     "content": data_files,
-                    "height": max(300, 40 * len(data_files)),
                 },
                 higlass_item={
                     "uuid": info.get("higlass_item_uuid", None),
@@ -2007,7 +2004,6 @@ def create_or_update_higlass_item(connection, files, attributions, higlass_item,
         files(dict)         : Info on the files used to create the viewconfig and Item. Also sets Item status.
             reference(list)     : A list of Reference files accessions
             content(list)       : A list of file dicts.
-            height(integer, optional, default=300): The maximum height of the Higlass Item.
         attributions(dict)  : Higlass Item permission settings using uuids.
             lab(string)
             contributing_labs(list) : A list of contributing lab uuids.
@@ -2028,9 +2024,6 @@ def create_or_update_higlass_item(connection, files, attributions, higlass_item,
     # start with the reference files and add the target files
     file_accessions = [ f["accession"] for f in files["content"] ]
     to_post = {'files': files["reference"] + file_accessions}
-
-    # Add the height
-    to_post["height"] = files.get("height", 300)
 
     # post the files to the visualization endpoint
     res = requests.post(

--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -1659,7 +1659,6 @@ def files_not_registered_with_higlass(connection, **kwargs):
         search_queries_by_type[file_cat] = search_query
 
     for file_cat, search_query in search_queries_by_type.items():
-
         # Skip if there is no search query (most likely it was filtered out)
         if not search_query:
             continue
@@ -1703,7 +1702,8 @@ def files_not_registered_with_higlass(connection, **kwargs):
                         and extra.get("status", unpublished_statuses[-1]) not in unpublished_statuses:
                         file_info['upload_key'] = extra['upload_key']
                         break
-                if 'upload_key' not in file_info:  # bw or beddb file not found
+                if 'upload_key' not in file_info:
+                    # bw or beddb file not found, do not consider this file for registration
                     continue
             else:
                 # mcool and bw files use themselves
@@ -1712,6 +1712,7 @@ def files_not_registered_with_higlass(connection, **kwargs):
                 else:
                     not_found_upload_key.append(file_info['accession'])
                     continue
+
             # make sure file exists on s3
             typebucket_by_cat = {
                 "raw" : connection.ff_s3.raw_file_bucket,

--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -10,6 +10,7 @@ from dcicutils import ff_utils
 import requests
 import json
 import time
+import uuid
 from copy import deepcopy
 
 def get_reference_files(connection):
@@ -1867,9 +1868,13 @@ def patch_file_higlass_uid(connection, **kwargs):
                 err_msg = 'No filetype case specified for %s' % ftype
                 action_logs['registration_failure'][hit['accession']] = err_msg
                 continue
+
             # register with previous higlass_uid if already there
+            # otherwise, specify our own new higlass_uid with slugid
             if hit.get('higlass_uid') and not kwargs['force_new_higlass_uid']:
                 payload['uuid'] = hit['higlass_uid']
+            else:
+                payload['uuid'] = str(uuid.uuid4())
 
             res = requests.post(
                 higlass_server + '/api/v1/link_tile/',

--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -10,7 +10,6 @@ from dcicutils import ff_utils
 import requests
 import json
 import time
-import re
 from copy import deepcopy
 
 def get_reference_files(connection):
@@ -1884,11 +1883,6 @@ def patch_file_higlass_uid(connection, **kwargs):
                 action_logs['registration_success'] += 1
                 # Get higlass's uuid. This is Fourfront's higlass_uid.
                 response_higlass_uid = res.json()['uuid']
-
-                # Higlass server may have returned a bytestring, and Python forced that into a string. Remove the b'' section.
-                matches = re.match("b'([^']+)'", res.json()['uuid'])
-                if matches and matches.groups():
-                    response_higlass_uid = matches.group(1)
 
                 if 'higlass_uid' not in hit or hit['higlass_uid'] != response_higlass_uid:
                     patch_data = {'higlass_uid': response_higlass_uid}


### PR DESCRIPTION
Some fixes for the Higlass checks, especially when registering files on higlass:

- chromsizes files now use a different url when checking to see if they are registered.
- Adding a `force_new_higlass_uid` argument so we can regenerate a new higlass_uid if the previous one has changed/needs to be regenerated.
- Action shows the files and their new higlass_uids.
- The higlass server began sending bytestrings as higlass_uids. Instead we'll use the uuid library so we get encoded strings for IDs.