### PR TITLE
allow_action_fix: Higlass File registration should act only if there are files to act on.

### DIFF
--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -1754,7 +1754,6 @@ def files_not_registered_with_higlass(connection, **kwargs):
         check.status = 'PASS'
 
     file_count = sum([len(files_to_be_reg[ft]) for ft in files_to_be_reg])
-    check.allow_action = False
 
     if file_count != 0:
         check.status = 'WARN'

--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -1754,11 +1754,14 @@ def files_not_registered_with_higlass(connection, **kwargs):
         check.status = 'PASS'
 
     file_count = sum([len(files_to_be_reg[ft]) for ft in files_to_be_reg])
+    check.allow_action = False
+
     if file_count != 0:
         check.status = 'WARN'
+        check.allow_action = True
     if check.summary:
         if file_count != 0:
-            check.summary += ' %s files ready for registration' % file_count
+            check.summary += ' %s files ready for registration.' % file_count
             check.description += ' %s files ready for registration.' % file_count
         elif check.status == 'PASS':
             check.summary += ' All files are registered.'
@@ -1768,16 +1771,14 @@ def files_not_registered_with_higlass(connection, **kwargs):
             check.description += ' No files to register.'
 
         if not kwargs['confirm_on_higlass']:
-            check.description += "Run with confirm_on_higlass=True to check against the higlass server"
+            check.description += " Run with confirm_on_higlass=True to check against the higlass server"
     else:
         check.summary = ' %s files ready for registration' % file_count
         check.description = check.summary
         if not kwargs['confirm_on_higlass']:
             check.description += "Run with confirm_on_higlass=True to check against the higlass server"
 
-
     check.action_message = "Will attempt to patch higlass_uid for %s files." % file_count
-    check.allow_action = True
     return check
 
 @action_function(file_accession=None, force_new_higlass_uid=False)


### PR DESCRIPTION
Burak noticed the files_not_registered_with_higlass action showed the "there is an action you can run" indicator, even if there are no files to register. I have moved that flag so it is only True when there are files to register.

