### PR TITLE
queue_action_higlass: Prod Higlass checks now trigger the action.

### DIFF
--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -403,7 +403,7 @@
         "schedule": {
             "morning_checks": {
                 "data": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {"primary": true, "queue_action": true},
                     "dependencies": []
                 },
                 "webdev": {
@@ -741,7 +741,7 @@
         "schedule": {
             "hourly_checks": {
                 "data": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {"primary": true, "queue_action": true},
                     "dependencies": []
                 },
                 "webdev": {
@@ -761,7 +761,7 @@
         "schedule": {
             "hourly_checks_2": {
                 "data": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {"primary": true, "queue_action": true},
                     "dependencies": []
                 },
                 "webdev": {
@@ -787,7 +787,7 @@
         "schedule": {
             "hourly_checks": {
                 "data": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {"primary": true, "queue_action": true},
                     "dependencies": []
                 },
                 "webdev": {
@@ -807,7 +807,7 @@
         "schedule": {
             "hourly_checks_2": {
                 "data": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {"primary": true, "queue_action": true},
                     "dependencies": []
                 },
                 "webdev": {
@@ -833,7 +833,7 @@
         "schedule": {
             "morning_checks": {
                 "data": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {"primary": true, "queue_action": true},
                     "dependencies": []
                 },
                 "webdev": {

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -837,7 +837,7 @@
                     "dependencies": []
                 },
                 "webdev": {
-                    "kwargs": {"primary": true, "queue_action": true,
+                    "kwargs": {"primary": true, "queue_action": true},
                     "dependencies": []
                 },
                 "hotseat": {

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -407,7 +407,7 @@
                     "dependencies": []
                 },
                 "webdev": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {"primary": true, "queue_action": true},
                     "dependencies": []
                 }
             }
@@ -745,7 +745,7 @@
                     "dependencies": []
                 },
                 "webdev": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {"primary": true, "queue_action": true},
                     "dependencies": []
                 },
                 "hotseat": {
@@ -791,7 +791,7 @@
                     "dependencies": []
                 },
                 "webdev": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {"primary": true, "queue_action": true},
                     "dependencies": []
                 },
                 "hotseat": {
@@ -811,7 +811,7 @@
                     "dependencies": []
                 },
                 "webdev": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {"primary": true, "queue_action": true},
                     "dependencies": []
                 },
                 "hotseat": {
@@ -837,7 +837,7 @@
                     "dependencies": []
                 },
                 "webdev": {
-                    "kwargs": {"primary": true},
+                    "kwargs": {"primary": true, "queue_action": true,
                     "dependencies": []
                 },
                 "hotseat": {


### PR DESCRIPTION
As discussed, the Higlass checks should automatically act if they allow actions.

I'll enable this for production (aka data) so we don't have to manually activate them every day. For other servers I did not enable this. Most of the time we don't need to actually act, and we may be interested in manually inspecting the check first.