### PR TITLE
Use keys instead of ff_env for ff_utils

### DIFF
--- a/chalicelib/checks/audit_checks.py
+++ b/chalicelib/checks/audit_checks.py
@@ -47,7 +47,7 @@ def biosource_cell_line_value(connection, **kwargs):
                        "in vitro differentiated cells", "induced pluripotent stem cell line",
                        "stem cell", "stem cell derived cell line"]
     biosources = ff_utils.search_metadata('search/?type=Biosource&frame=object',
-                                          ff_env=connection.ff_env, page_limit=200)
+                                          key=connection.ff_keys, page_limit=200)
     missing = []
     for biosource in biosources:
         # check if the biosource type is a cell/cell line
@@ -78,7 +78,7 @@ def external_expsets_without_pub(connection, **kwargs):
     check = init_check_res(connection, 'external_expsets_without_pub')
 
     ext = ff_utils.search_metadata('search/?award.project=External&type=ExperimentSet&frame=object',
-                                   ff_env=connection.ff_env, page_limit=50)
+                                   key=connection.ff_keys, page_limit=50)
     no_pub = []
     for expset in ext:
         if not expset.get('publications_of_set') and not expset.get('produced_in_pub'):
@@ -109,7 +109,7 @@ def expset_opfsets_unique_titles(connection, **kwargs):
     check = init_check_res(connection, 'expset_opfsets_unique_titles')
 
     opf_expsets = ff_utils.search_metadata('search/?type=ExperimentSet&other_processed_files.files.uuid%21=No+value&frame=object',
-                                           ff_env=connection.ff_env, page_limit=50)
+                                           key=connection.ff_keys, page_limit=50)
     errors = []
     for expset in opf_expsets:
         e = []
@@ -152,7 +152,7 @@ def expset_opf_unique_files_in_experiments(connection, **kwargs):
     check = init_check_res(connection, 'expset_opf_unique_files_in_experiments')
 
     opf_expsets = ff_utils.search_metadata('search/?type=ExperimentSet&other_processed_files.files.uuid%21=No+value',
-                                           ff_env=connection.ff_env, page_limit=25)
+                                           key=connection.ff_keys, page_limit=25)
     errors = []
     for expset in opf_expsets:
         expset_titles = {fileset.get('title'): fileset.get('files') for fileset in expset['other_processed_files'] if fileset.get('title')}
@@ -203,8 +203,8 @@ def paired_end_info_consistent(connection, **kwargs):
     search1 = 'search/?type=FileFastq&related_files.relationship_type=paired+with&paired_end=No+value'
     search2 = 'search/?type=FileFastq&related_files.relationship_type!=paired+with&paired_end%21=No+value'
 
-    results1 = ff_utils.search_metadata(search1 + '&frame=object', ff_env=connection.ff_env)
-    results2 = ff_utils.search_metadata(search2 + '&frame=object', ff_env=connection.ff_env)
+    results1 = ff_utils.search_metadata(search1 + '&frame=object', key=connection.ff_keys)
+    results2 = ff_utils.search_metadata(search2 + '&frame=object', key=connection.ff_keys)
 
     results = {'paired with file missing paired_end number':
                [result1['@id'] for result1 in results1],
@@ -232,7 +232,7 @@ def workflow_properties(connection, **kwargs):
     check = init_check_res(connection, 'workflow_properties')
 
     workflows = ff_utils.search_metadata('search/?type=Workflow&category!=provenance&frame=object',
-                                         ff_env=connection.ff_env)
+                                         key=connection.ff_keys)
     bad = {'Duplicate Input Names in Workflow Step': [],
            'Duplicate Output Names in Workflow Step': [],
            'Duplicate Input Source Names in Workflow Step': [],
@@ -311,7 +311,7 @@ def page_children_routes(connection, **kwargs):
     check = init_check_res(connection, 'page_children_routes')
 
     page_search = 'search/?type=Page&format=json&children.name%21=No+value'
-    results = ff_utils.search_metadata(page_search, ff_env=connection.ff_env)
+    results = ff_utils.search_metadata(page_search, key=connection.ff_keys)
     problem_routes = {}
     for result in results:
         bad_children = [child['name'] for child in result['children'] if
@@ -336,9 +336,9 @@ def page_children_routes(connection, **kwargs):
 def check_help_page_urls(connection, **kwargs):
     check = init_check_res(connection, 'check_help_page_urls')
 
-    server = ff_utils.get_authentication_with_server(ff_env=connection.ff_env)['server']
+    server = connection.ff_keys['server']
     results = ff_utils.search_metadata('search/?type=StaticSection&q=help&status!=draft&field=body',
-                                       ff_env=connection.ff_env)
+                                       key=connection.ff_keys)
     sections_w_broken_links = {}
     for result in results:
         broken_links = []
@@ -369,7 +369,6 @@ def check_help_page_urls(connection, **kwargs):
 def check_status_mismatch(connection, **kwargs):
     check = init_check_res(connection, 'check_status_mismatch')
     id_list = kwargs['id_list']
-    ffkey = ff_utils.get_authentication_with_server(ff_env=connection.ff_env)
 
     MIN_CHUNK_SIZE = 200
     # embedded sub items should have an equal or greater level
@@ -389,9 +388,9 @@ def check_status_mismatch(connection, **kwargs):
         itemids = re.split(',|\s+', id_list)
         itemids = [id for id in itemids if id]
     else:
-        itemres = ff_utils.search_metadata(item_search, key=ffkey, page_limit=500)
+        itemres = ff_utils.search_metadata(item_search, key=connection.ff_keys, page_limit=500)
         itemids = [item.get('uuid') for item in itemres]
-    es_items = ff_utils.get_es_metadata(itemids, key=ffkey, chunk_size=200, is_generator=True)
+    es_items = ff_utils.get_es_metadata(itemids, key=connection.ff_keys, chunk_size=200, is_generator=True)
     for es_item in es_items:
         label = es_item.get('embedded').get('display_title')
         desc = es_item.get('object').get('description')
@@ -480,8 +479,8 @@ def check_opf_status_mismatch(connection, **kwargs):
     opf_exp = ('search/?type=ExperimentSet&other_processed_files.title=No+value'
                '&experiments_in_set.other_processed_files.title%21=No+value'
                '&field=experiments_in_set.other_processed_files&field=status')
-    opf_set_results = ff_utils.search_metadata(opf_set, ff_env=connection.ff_env)
-    opf_exp_results = ff_utils.search_metadata(opf_exp, ff_env=connection.ff_env)
+    opf_set_results = ff_utils.search_metadata(opf_set, key=connection.ff_keys)
+    opf_exp_results = ff_utils.search_metadata(opf_exp, key=connection.ff_keys)
     results = opf_set_results + opf_exp_results
     # extract file uuids
     files = []
@@ -494,7 +493,7 @@ def check_opf_status_mismatch(connection, **kwargs):
                 for case in exp['other_processed_files']:
                     files.extend([i['uuid'] for i in case['files']])
     # get metadata for files, to collect status
-    resp =  ff_utils.get_es_metadata(files, chunk_size=1000, ff_env=connection.ff_env)
+    resp =  ff_utils.get_es_metadata(files, chunk_size=1000, key=connection.ff_keys)
     status_dict = {f['uuid']: f['properties']['status'] for f in resp}
     check.full_output = {}
     for result in results:
@@ -540,7 +539,7 @@ def check_validation_errors(connection, **kwargs):
     check = init_check_res(connection, 'check_validation_errors')
 
     search_url = 'search/?validation_errors.name!=No+value&type=Item'
-    results = ff_utils.search_metadata(search_url + '&field=@id', ff_env=connection.ff_env)
+    results = ff_utils.search_metadata(search_url + '&field=@id', key=connection.ff_keys)
     if results:
         types = {item for result in results for item in result['@type'] if item != 'Item'}
         check.status = 'WARN'
@@ -590,18 +589,18 @@ def check_bio_feature_organism_name(connection, **kwargs):
 
     # create some mappings
     organism_search = 'search/?type=Organism'
-    organisms = ff_utils.search_metadata(organism_search, ff_env=connection.ff_env)
+    organisms = ff_utils.search_metadata(organism_search, key=connection.ff_keys)
     orgn2name = {o.get('@id'): o.get('name') for o in organisms}
     # add special cases
     orgn2name['unspecified'] = 'unspecified'
     orgn2name['multiple organisms'] = 'multiple organisms'
     genome2orgn = {o.get('genome_assembly'): o.get('@id') for o in organisms if 'genome_assembly' in o}
     gene_search = 'search/?type=Gene'
-    genes = ff_utils.search_metadata(gene_search, ff_env=connection.ff_env)
+    genes = ff_utils.search_metadata(gene_search, key=connection.ff_keys)
     gene2org = {g.get('@id'): g.get('organism').get('@id') for g in genes}
     # get all BioFeatures
     biofeat_search = 'search/?type=BioFeature'
-    biofeatures = ff_utils.search_metadata(biofeat_search, ff_env=connection.ff_env)
+    biofeatures = ff_utils.search_metadata(biofeat_search, key=connection.ff_keys)
 
     matches = 0
     name_trumps_guess = 0
@@ -629,7 +628,8 @@ def check_bio_feature_organism_name(connection, **kwargs):
                             assembly_in_dt = True
                             break
                     if not assembly_in_dt:
-                        gr_res = ff_utils.get_es_metadata([genreg.get('uuid')], ff_env=connection.ff_env, sources=['properties.genome_assembly'])
+                        gr_res = ff_utils.get_es_metadata([genreg.get('uuid')],
+                                                          key=connection.ff_keys, sources=['properties.genome_assembly'])
                         try:
                             gr_ass = gr_res[0].get('properties').get('genome_assembly')
                         except AttributeError:
@@ -720,7 +720,7 @@ def patch_bio_feature_organism_name(connection, **kwargs):
     if patches:
         for uid, val in patches.items():
             try:
-                res = ff_utils.patch_metadata(val, uid, ff_env=connection.ff_env)
+                res = ff_utils.patch_metadata(val, uid, key=connection.ff_keys)
             except:
                 action_logs['patch_failure'].append(uid)
             else:

--- a/chalicelib/checks/header_checks.py
+++ b/chalicelib/checks/header_checks.py
@@ -24,12 +24,10 @@ def find_items_for_header_processing(connection, check, header, add_search=None,
     # sets the full_output of the check!
     check.full_output = {'static_section': header, 'to_add': {}, 'to_remove': {}}
     # this GET will fail if the static header does not exist
-    header_res = ff_utils.get_metadata(header, key=connection.ff_keys, ff_env=connection.ff_env)
+    header_res = ff_utils.get_metadata(header, key=connection.ff_keys)
     # add entries keyed by item uuid with value of the static headers
     if add_search:
-        search_res_add = ff_utils.search_metadata(add_search,
-                                                  key=connection.ff_keys,
-                                                  ff_env=connection.ff_env)
+        search_res_add = ff_utils.search_metadata(add_search, key=connection.ff_keys)
         for search_res in search_res_add:
             curr_headers = search_res.get('static_headers', [])
             # handle case where frame != object
@@ -41,8 +39,7 @@ def find_items_for_header_processing(connection, check, header, add_search=None,
 
     if remove_search:
         search_res_remove = ff_utils.search_metadata(remove_search,
-                                                     key=connection.ff_keys,
-                                                     ff_env=connection.ff_env)
+                                                     key=connection.ff_keys)
         for search_res in search_res_remove:
             curr_headers = search_res.get('static_headers', [])
             # handle case where frame != object
@@ -84,7 +81,7 @@ def patch_items_with_headers(connection, action, kwargs):
         # if all headers are deleted, use ff_utils.delete_field
         if headers == []:
             try:
-                ff_utils.delete_field(item, 'static_headers', key=connection.ff_keys, ff_env=connection.ff_env)
+                ff_utils.delete_field(item, 'static_headers', key=connection.ff_keys)
             except Exception as e:
                 patch_error = '\n'.join([item, str(e)])
                 action_logs['patch_failure'].append(patch_error)
@@ -93,7 +90,7 @@ def patch_items_with_headers(connection, action, kwargs):
         else:
             patch_data = {'static_headers': headers}
             try:
-                ff_utils.patch_metadata(patch_data, obj_id=item, key=connection.ff_keys, ff_env=connection.ff_env)
+                ff_utils.patch_metadata(patch_data, obj_id=item, key=connection.ff_keys)
             except Exception as e:
                 patch_error = '\n'.join([item, str(e)])
                 action_logs['patch_failure'].append(patch_error)

--- a/chalicelib/checks/release_updates_checks.py
+++ b/chalicelib/checks/release_updates_checks.py
@@ -427,10 +427,10 @@ def experiment_set_reporting_data(connection, **kwargs):
     check.status = 'IGNORE'
     exp_sets = {}
     search_query = '/search/?type=ExperimentSetReplicate&experimentset_type=replicate&sort=-date_created'
-    set_hits = ff_utils.search_metadata(search_query, ff_env=connection.ff_env, page_limit=20)
+    set_hits = ff_utils.search_metadata(search_query, key=connection.ff_keys, page_limit=20)
     # run a second search for status=deleted and status=replaced
     set_hits_del = ff_utils.search_metadata(search_query + '&status=deleted&status=replaced',
-                                            ff_env=connection.ff_env, page_limit=20)
+                                            key=connection.ff_keys, page_limit=20)
     set_hits.extend(set_hits_del)
     for hit in set_hits:
         add_to_report(hit, exp_sets)
@@ -624,10 +624,10 @@ def publish_data_release_updates(connection, **kwargs):
     posted_updates = []
     for update in updates_to_post:
         # should be in good shape to post as-is
-        resp = ff_utils.post_metadata(update, 'data-release-updates', key=connection.ff_keys, ff_env=connection.ff_env)
+        resp = ff_utils.post_metadata(update, 'data-release-updates', key=connection.ff_keys)
         posted_updates.append({'update': update, 'response': resp})
     if section_to_post:
-        resp = ff_utils.post_metadata(section_to_post, 'static-sections', key=connection.ff_keys, ff_env=connection.ff_env)
+        resp = ff_utils.post_metadata(section_to_post, 'static-sections', key=connection.ff_keys)
         posted_section = {'static_section': section_to_post, 'response': resp}
     else:
         posted_section = None

--- a/chalicelib/checks/system_checks.py
+++ b/chalicelib/checks/system_checks.py
@@ -232,7 +232,8 @@ def fourfront_performance_metrics(connection, **kwargs):
         performance[check_url] = {}
         try:
             # set timeout really high
-            ff_resp = ff_utils.authorized_request(connection.ff_server + check_url, timeout=1000)
+            ff_resp = ff_utils.authorized_request(connection.ff_server + check_url,
+                                                  auth=connection.ff_keys, timeout=1000)
         except Exception as e:
             performance[check_url]['error'] = str(e)
         if ff_resp and hasattr(ff_resp, 'headers') and 'X-stats' in ff_resp.headers:
@@ -297,7 +298,7 @@ def secondary_queue_deduplication(connection, **kwargs):
     # get the maximum sid at the start of deduplication and update it if we
     # encounter a higher sid
     max_sid_resp = ff_utils.authorized_request(connection.ff_server + 'max-sid',
-                                               key=connection.ff_keys).json()
+                                               auth=connection.ff_keys).json()
     if max_sid_resp['status'] != 'success':
         check.status = 'FAIL'
         check.summary = 'Could not retrieve max_sid from the server'

--- a/chalicelib/checks/system_checks.py
+++ b/chalicelib/checks/system_checks.py
@@ -232,7 +232,7 @@ def fourfront_performance_metrics(connection, **kwargs):
         performance[check_url] = {}
         try:
             # set timeout really high
-            ff_resp = ff_utils.authorized_request(connection.ff_server + check_url, ff_env=connection.ff_env, timeout=1000)
+            ff_resp = ff_utils.authorized_request(connection.ff_server + check_url, timeout=1000)
         except Exception as e:
             performance[check_url]['error'] = str(e)
         if ff_resp and hasattr(ff_resp, 'headers') and 'X-stats' in ff_resp.headers:
@@ -297,7 +297,7 @@ def secondary_queue_deduplication(connection, **kwargs):
     # get the maximum sid at the start of deduplication and update it if we
     # encounter a higher sid
     max_sid_resp = ff_utils.authorized_request(connection.ff_server + 'max-sid',
-                                               ff_env=connection.ff_env).json()
+                                               key=connection.ff_keys).json()
     if max_sid_resp['status'] != 'success':
         check.status = 'FAIL'
         check.summary = 'Could not retrieve max_sid from the server'
@@ -557,7 +557,7 @@ def process_download_tracking_items(connection, **kwargs):
     range_search_query = ''.join(['search/?type=TrackingItem&tracking_type=download_tracking',
                                   '&download_tracking.range_query=true&sort=-date_created',
                                   '&status=released&q=last_modified.date_modified:>=', cons_date])
-    cons_query = ff_utils.search_metadata(range_search_query, key=connection.ff_keys, ff_env=connection.ff_env)
+    cons_query = ff_utils.search_metadata(range_search_query, key=connection.ff_keys)
     for tracking in cons_query:
         dl_info = tracking['download_tracking']
         range_key = '//'.join([dl_info['remote_ip'], dl_info['filename'],
@@ -583,8 +583,7 @@ def process_download_tracking_items(connection, **kwargs):
     search_query = ''.join(['search/?type=TrackingItem&tracking_type=download_tracking',
                             '&download_tracking.geo_country=No+value',
                             '&status=in+review+by+lab&sort=-date_created&limit=', str(search_limit)])
-    search_page = ff_utils.search_metadata(search_query, key=connection.ff_keys,
-                                           ff_env=connection.ff_env, page_limit=200)
+    search_page = ff_utils.search_metadata(search_query, key=connection.ff_keys, page_limit=200)
     counts = {'proc': 0, 'deleted': 0, 'released': 0}
 
     page_ips = set([tracking['download_tracking']['remote_ip'] for tracking in search_page])
@@ -639,8 +638,7 @@ def process_download_tracking_items(connection, **kwargs):
             else:
                 # set the upper limit for for range queries to consolidate
                 range_cache[range_key] = [parsed_date]
-        ff_utils.patch_metadata(patch_body, tracking['uuid'],
-                                key=connection.ff_keys, ff_env=connection.ff_env)
+        ff_utils.patch_metadata(patch_body, tracking['uuid'], key=connection.ff_keys)
         counts['proc'] += 1
         if patch_body['status'] == 'released':
             counts['released'] += 1
@@ -672,21 +670,19 @@ def purge_download_tracking_items(connection, **kwargs):
     t0 = time.time()
     check.full_output = {}  # purged items by item type
     search = '/search/?type=TrackingItem&tracking_type=download_tracking&status=deleted&field=uuid&limit=300'
-    search_res = ff_utils.search_metadata(search, key=connection.ff_keys,
-                                          ff_env=connection.ff_env)
+    search_res = ff_utils.search_metadata(search, key=connection.ff_keys)
     search_uuids = [res['uuid'] for res in search_res]
     client = es_utils.create_es_client(connection.ff_es, True)
     # a bit convoluted, but we want the frame=raw, which does not include uuid
     # use get_es_metadata to handle this. Use it as a generator
     for to_purge in ff_utils.get_es_metadata(search_uuids, es_client=client, is_generator=True,
-                                    key=connection.ff_keys, ff_env=connection.ff_env):
+                                             key=connection.ff_keys):
         if round(time.time() - t0, 2) > time_limit:
             break
         purge_properties = to_purge['properties']
         purge_properties['uuid'] = to_purge['uuid']  # add uuid to frame=raw
         try:
-            purge_res = ff_utils.purge_metadata(to_purge['uuid'], key=connection.ff_keys,
-                                                ff_env=connection.ff_env)
+            purge_res = ff_utils.purge_metadata(to_purge['uuid'], key=connection.ff_keys)
         except Exception as exc:
             purge_status = 'error'
             purge_detail = str(exc)

--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -798,8 +798,7 @@ def clean_up_webdev_wfrs(connection, **kwargs):
         if uuid in full_output['success']:
             return
         try:
-            ff_utils.patch_metadata(patch_json, uuid, key=connection.ff_keys,
-                                    key=connection.ff_keys)
+            ff_utils.patch_metadata(patch_json, uuid, key=connection.ff_keys)
         except Exception as exc:
             # log something about str(exc)
             full_output['failure'].append('%s. %s' % (uuid, str(exc)))
@@ -812,7 +811,7 @@ def clean_up_webdev_wfrs(connection, **kwargs):
 
     # input for test pseudo hi-c-processing-bam
     response = ff_utils.get_metadata('68f38e45-8c66-41e2-99ab-b0b2fcd20d45',
-                                     key=connection.ff_keys, key=connection.ff_keys)
+                                     key=connection.ff_keys)
     wfrlist = response['workflow_run_inputs']
     for entry in wfrlist:
         patch_wfr_and_log(entry, check.full_output)
@@ -823,14 +822,14 @@ def clean_up_webdev_wfrs(connection, **kwargs):
 
     # input for test md5 and bwa-mem
     response = ff_utils.get_metadata('f4864029-a8ad-4bb8-93e7-5108f462ccaa',
-                                     key=connection.ff_keys, key=connection.ff_keys)
+                                     key=connection.ff_keys)
     wfrlist = response['workflow_run_inputs']
     for entry in wfrlist:
         patch_wfr_and_log(entry, check.full_output)
 
     # input for test md5 and bwa-mem
     response = ff_utils.get_metadata('f4864029-a8ad-4bb8-93e7-5108f462ccaa',
-                                     key=connection.ff_keys, key=connection.ff_keys)
+                                     key=connection.ff_keys)
     wfrlist = response['workflow_run_inputs']
     for entry in wfrlist:
         patch_wfr_and_log(entry, check.full_output)

--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -132,7 +132,7 @@ def biorxiv_is_now_published(connection, **kwargs):
         suffix = 'journal=bioRxiv&type=Publication&status=current&limit=all'
     # run the check
     search_query = search + suffix
-    biorxivs = ff_utils.search_metadata(search_query, key=connection.ff_keys, ff_env=connection.ff_env)
+    biorxivs = ff_utils.search_metadata(search_query, key=connection.ff_keys)
     if not biorxivs:
         check.status = "FAIL"
         check.description = "Could not retrieve biorxiv records from fourfront"
@@ -439,7 +439,7 @@ def item_counts_by_type(connection, **kwargs):
     item_counts = {}
     warn_item_counts = {}
     req_location = ''.join([connection.ff_server, 'counts?format=json'])
-    counts_res = ff_utils.authorized_request(req_location, ff_env=connection.ff_env)
+    counts_res = ff_utils.authorized_request(req_location, auth=connection.ff_keys)
     if counts_res.status_code >= 400:
         check.status = 'ERROR'
         check.description = 'Error (bad status code %s) connecting to the counts endpoint at: %s.' % (counts_res.status_code, req_location)
@@ -507,10 +507,10 @@ def change_in_item_counts(connection, **kwargs):
     search_query = ''.join(['search/?type=Item&type=OntologyTerm&type=TrackingItem',
                             '&frame=object&date_created.from=',
                             from_date, '&date_created.to=', to_date])
-    search_resp = ff_utils.search_metadata(search_query, key=connection.ff_keys, ff_env=connection.ff_env)
+    search_resp = ff_utils.search_metadata(search_query, key=connection.ff_keys)
     # add deleted/replaced items
     search_query += '&status=deleted&status=replaced'
-    search_resp.extend(ff_utils.search_metadata(search_query, key=connection.ff_keys, ff_env=connection.ff_env))
+    search_resp.extend(ff_utils.search_metadata(search_query, key=connection.ff_keys))
     search_output = []
     for res in search_resp:
         # convert type to index name. e.g. ExperimentSet --> experiment_set
@@ -572,7 +572,7 @@ def identify_files_without_filesize(connection, **kwargs):
             addon = '&' + addon
         search_query += addon
     problem_files = []
-    file_hits = ff_utils.search_metadata(search_query, ff_env=connection.ff_env, page_limit=200)
+    file_hits = ff_utils.search_metadata(search_query, key=connection.ff_keys, page_limit=200)
     if not file_hits:
         check.status = 'PASS'
         return check
@@ -619,7 +619,7 @@ def patch_file_size(connection, **kwargs):
         else:
             patch_data = {'file_size': head_info['ContentLength']}
             try:
-                ff_utils.patch_metadata(patch_data, obj_id=hit['uuid'], key=connection.ff_keys, ff_env=connection.ff_env)
+                ff_utils.patch_metadata(patch_data, obj_id=hit['uuid'], key=connection.ff_keys)
             except Exception as e:
                 acc_and_error = '\n'.join([hit['accession'], str(e)])
                 action_logs['patch_failure'].append(acc_and_error)
@@ -668,7 +668,7 @@ def new_or_updated_items(connection, **kwargs):
         if user in seen and user not in dcic:
             return seen.get(user)
 
-        user_item = ff_utils.get_metadata(user, ff_env=connection.ff_env)
+        user_item = ff_utils.get_metadata(user, key=connection.ff_keys)
         seen[user] = user_item.get('display_title')
         if user_item.get('lab').get('display_title') == dciclab:
             dcic[user] = True
@@ -710,7 +710,7 @@ def new_or_updated_items(connection, **kwargs):
     types2chk = ['ExperimentSet', 'Experiment']
     for itype in types2chk:
         chk_query = search.format(type=itype)
-        item_results = ff_utils.search_metadata(chk_query, ff_env=connection.ff_env, page_limit=200)
+        item_results = ff_utils.search_metadata(chk_query, key=connection.ff_keys, page_limit=200)
         for item in item_results:
             submitter = None
             modifier = None
@@ -799,7 +799,7 @@ def clean_up_webdev_wfrs(connection, **kwargs):
             return
         try:
             ff_utils.patch_metadata(patch_json, uuid, key=connection.ff_keys,
-                                    ff_env=connection.ff_env)
+                                    key=connection.ff_keys)
         except Exception as exc:
             # log something about str(exc)
             full_output['failure'].append('%s. %s' % (uuid, str(exc)))
@@ -812,7 +812,7 @@ def clean_up_webdev_wfrs(connection, **kwargs):
 
     # input for test pseudo hi-c-processing-bam
     response = ff_utils.get_metadata('68f38e45-8c66-41e2-99ab-b0b2fcd20d45',
-                                     key=connection.ff_keys, ff_env=connection.ff_env)
+                                     key=connection.ff_keys, key=connection.ff_keys)
     wfrlist = response['workflow_run_inputs']
     for entry in wfrlist:
         patch_wfr_and_log(entry, check.full_output)
@@ -823,14 +823,14 @@ def clean_up_webdev_wfrs(connection, **kwargs):
 
     # input for test md5 and bwa-mem
     response = ff_utils.get_metadata('f4864029-a8ad-4bb8-93e7-5108f462ccaa',
-                                     key=connection.ff_keys, ff_env=connection.ff_env)
+                                     key=connection.ff_keys, key=connection.ff_keys)
     wfrlist = response['workflow_run_inputs']
     for entry in wfrlist:
         patch_wfr_and_log(entry, check.full_output)
 
     # input for test md5 and bwa-mem
     response = ff_utils.get_metadata('f4864029-a8ad-4bb8-93e7-5108f462ccaa',
-                                     key=connection.ff_keys, ff_env=connection.ff_env)
+                                     key=connection.ff_keys, key=connection.ff_keys)
     wfrlist = response['workflow_run_inputs']
     for entry in wfrlist:
         patch_wfr_and_log(entry, check.full_output)
@@ -856,7 +856,7 @@ def validate_entrez_geneids(connection, **kwargs):
     problems = {}
     timeouts = 0
     search_query = 'search/?type=Gene&limit=all&field=geneid'
-    genes = ff_utils.search_metadata(search_query, key=connection.ff_keys, ff_env=connection.ff_env)
+    genes = ff_utils.search_metadata(search_query, key=connection.ff_keys)
     if not genes:
         check.status = "FAIL"
         check.description = "Could not retrieve gene records from fourfront"
@@ -919,7 +919,7 @@ def users_with_pending_lab(connection, **kwargs):
         emails = [mail.strip() for mail in scope.split(',')]
         for an_email in emails:
             search_q += '&email=' + an_email
-    search_res = ff_utils.search_metadata(search_q, key=connection.ff_keys, ff_env=connection.ff_env)
+    search_res = ff_utils.search_metadata(search_q, key=connection.ff_keys)
     for res in search_res:
         user_fields = ['uuid', 'email', 'pending_lab', 'lab', 'title', 'job_title']
         user_append = {k: res.get(k) for k in user_fields}
@@ -933,11 +933,11 @@ def users_with_pending_lab(connection, **kwargs):
         if user_append['pending_lab'] not in cached_items:
             to_cache = {}
             pending_meta = ff_utils.get_metadata(user_append['pending_lab'], key=connection.ff_keys,
-                                                 ff_env=connection.ff_env, add_on='frame=object')
+                                                 add_on='frame=object')
             to_cache['lab_title'] = pending_meta['display_title']
             if 'pi' in pending_meta:
                 pi_meta = ff_utils.get_metadata(pending_meta['pi'], key=connection.ff_keys,
-                                                ff_env=connection.ff_env, add_on='frame=object')
+                                                add_on='frame=object')
                 to_cache['lab_PI_email'] = pi_meta['email']
                 to_cache['lab_PI_title'] = pi_meta['title']
                 to_cache['lab_PI_viewing_groups'] = pi_meta['viewing_groups']
@@ -974,7 +974,7 @@ def finalize_user_pending_labs(connection, **kwargs):
         # patch lab and delete pending_lab in one request
         try:
             ff_utils.patch_metadata(patch_data, obj_id=user['uuid'], key=connection.ff_keys,
-                                    ff_env=connection.ff_env, add_on='delete_fields=pending_lab')
+                                    add_on='delete_fields=pending_lab')
         except Exception as e:
             action_logs['patch_failure'].append({user['uuid']: str(e)})
         else:
@@ -1151,7 +1151,7 @@ def check_assay_classification_short_names(connection, **kwargs):
         "immunofluorescence": "Immunofluorescence"
     }
     exptypes = ff_utils.search_metadata('search/?type=ExperimentType&frame=object',
-                                        ff_env=connection.ff_env)
+                                        key=connection.ff_keys)
     auto_patch = {}
     manual = {}
     for exptype in exptypes:
@@ -1199,7 +1199,7 @@ def patch_assay_subclass_short(connection, **kwargs):
     action_logs = {'patch_success': [], 'patch_failure': []}
     for k, v in check_res['full_output']['Patch by action'].items():
         try:
-            ff_utils.patch_metadata({'assay_subclass_short': v['new subclass_short']}, k, ff_env=connection.ff_env)
+            ff_utils.patch_metadata({'assay_subclass_short': v['new subclass_short']}, k, key=connection.ff_keys)
         except Exception as e:
             action_logs['patch_failure'].append({k: str(e)})
         else:

--- a/chalicelib/fs_connection.py
+++ b/chalicelib/fs_connection.py
@@ -15,18 +15,18 @@ class FSConnection(object):
     - ff_keys: FF keys for the environment with 'key', 'secret' and 'server'
     - ff_es: string server of the elasticsearch for the FF
     - s3_connection: S3Connection object that is the s3 connection for FS
-    
+
     If param test=True, then do not actually attempt to initate the FF connections
     """
     def __init__(self, fs_environ, fs_environ_info, test=False):
         # FOURSIGHT information
         self.fs_env = fs_environ
         self.s3_connection = S3Connection(fs_environ_info.get('bucket'))
-        
+
         # FOURFRONT information
-        self.ff_server = fs_environ_info.get('fourfront')
-        self.ff_env = fs_environ_info.get('ff_env')
-        self.ff_es = fs_environ_info.get('es')
+        self.ff_server = fs_environ_info['fourfront']
+        self.ff_env = fs_environ_info['ff_env']
+        self.ff_es = fs_environ_info['es']
         if not test:
             self.ff_s3 = s3Utils(env=self.ff_env)
             try:
@@ -34,6 +34,10 @@ class FSConnection(object):
             except Exception as e:
                 raise Exception('Could not initiate connection to Fourfront; it is probably a bad ff_env. '
                       'You gave: %s. Error message: %s' % (self.ff_env, str(e)))
+            # ensure ff_keys has server, and make sure it does not end with '/'
+            if 'server' not in self.ff_keys:
+                server = self.ff_server[:-1] if self.ff_server.endswith('/') else self.ff_server
+                self.ff_keys['server'] = server
         else:
             self.ff_s3 = None
             self.ff_keys = None

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -51,14 +51,13 @@ def items_created_in_the_past_day(connection, **kwargs):
     return check
 ```
 
-At the moment, this check won't do anything but write a result to the `items_created_in_the_past_day` check directory, which will have some default values (namely status=ERROR). So, the body of the check can be thought of as doing the computation necessary to fill those fields of the check result. To actually get our check to do something, let's import ff_utils module from the central dcicutils package, which allows us to easily make requests to Fourfront. Imports should generally be done at the top level of your checks file, but they are shown in the function here for completeness. It's important to note that we can always get the current Fourfront enviroment (such as `foufront-webdev` or `fourfront-webprod`) using the `connection.ff_env` field. This is leveraged to make connections in the ff_utils module.
+At the moment, this check won't do anything but write a result to the `items_created_in_the_past_day` check directory, which will have some default values (namely status=ERROR). So, the body of the check can be thought of as doing the computation necessary to fill those fields of the check result. To actually get our check to do something, let's import ff_utils module from the central dcicutils package, which allows us to easily make requests to Fourfront. Imports should generally be done at the top level of your checks file, but they are shown in the function here for completeness. It's important to note that we can always get Fourfront access keys through `connection.ff_keys`. Likewise, the current Fourfront environment (such as `foufront-webdev` or `fourfront-webprod`) using the `connection.ff_env` field. These are leveraged when using the ff_utils package.
 
 ```
 @check_function()
 def items_created_in_the_past_day(connection, **kwargs):
     from dcicutils import ff_utils
     check = init_check_res(connection, 'items_created_in_the_past_day')
-    # can get Fourfront environment with connection.ff_env
     check.status = 'PASS'
     check.description = 'Working description.'
     return check
@@ -77,7 +76,7 @@ def items_created_in_the_past_day(connection, **kwargs):
     date_str = (datetime.datetime.utcnow() - datetime.timedelta(days=1)).strftime('%Y-%m-%d')
     search_query = ''.join(['search/?type=', item_type, '&q=date_created:>=', date_str, '&frame=object'])
     # this will return a list of hits from the search
-    search_res = ff_utils.search_metadata(search_query, ff_env=connection.ff_env)
+    search_res = ff_utils.search_metadata(search_query, key=connection.ff_keys)
     full_output = {}
     item_output = []
     for res in search_res:


### PR DESCRIPTION
Use `key` instead of `ff_env` for performant use of ff_utils, since the latter requires looking up keys and server per call.