### PR TITLE
auth now checks for admin group

### DIFF
--- a/.chalice/deployed.json
+++ b/.chalice/deployed.json
@@ -1,0 +1,56 @@
+{
+    "prod": {
+      "api_handler_name": "foursight-prod",
+      "api_handler_arn": "arn:aws:lambda:us-east-1:643366669028:function:foursight-prod",
+      "lambda_functions": {
+        "foursight-prod-ten_min_checks": {
+          "arn": "arn:aws:lambda:us-east-1:643366669028:function:foursight-prod-ten_min_checks",
+          "type": "scheduled_event"
+        },
+        "foursight-prod-thirty_min_checks": {
+          "arn": "arn:aws:lambda:us-east-1:643366669028:function:foursight-prod-thirty_min_checks",
+          "type": "scheduled_event"
+        },
+        "foursight-prod-morning_checks": {
+          "arn": "arn:aws:lambda:us-east-1:643366669028:function:foursight-prod-morning_checks",
+          "type": "scheduled_event"
+        },
+        "foursight-prod-check_runner": {
+          "arn": "arn:aws:lambda:us-east-1:643366669028:function:foursight-prod-check_runner",
+          "type": "pure_lambda"
+        }
+      },
+      "backend": "api",
+      "chalice_version": "1.1.0",
+      "rest_api_id": "we0v248yi4",
+      "api_gateway_stage": "api",
+      "region": "us-east-1"
+    },
+    "dev": {
+      "api_handler_name": "foursight-dev",
+      "api_handler_arn": "arn:aws:lambda:us-east-1:643366669028:function:foursight-dev",
+      "lambda_functions": {
+        "foursight-dev-ten_min_checks": {
+          "arn": "arn:aws:lambda:us-east-1:643366669028:function:foursight-dev-ten_min_checks",
+          "type": "scheduled_event"
+        },
+        "foursight-dev-thirty_min_checks": {
+          "arn": "arn:aws:lambda:us-east-1:643366669028:function:foursight-dev-thirty_min_checks",
+          "type": "scheduled_event"
+        },
+        "foursight-dev-morning_checks": {
+          "arn": "arn:aws:lambda:us-east-1:643366669028:function:foursight-dev-morning_checks",
+          "type": "scheduled_event"
+        },
+        "foursight-dev-check_runner": {
+          "arn": "arn:aws:lambda:us-east-1:643366669028:function:foursight-dev-check_runner",
+          "type": "pure_lambda"
+        }
+      },
+      "backend": "api",
+      "chalice_version": "1.1.0",
+      "rest_api_id": "kpqxwgx646",
+      "api_gateway_stage": "api",
+      "region": "us-east-1"
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .chalice/deployments/
 .chalice/deployed/
-.chalice/deployed.json
 .chalice/venv/
 .chalice/config.json
 *.pyc

--- a/app.py
+++ b/app.py
@@ -124,11 +124,11 @@ def index():
 
 
 @app.route('/introspect', methods=['GET'])
-def introspect():
+def introspect(environ):
     """
     Test route
     """
-    auth = check_authorization(app.current_request.to_dict())
+    auth = check_authorization(app.current_request.to_dict(), environ)
     if auth:
         return Response(status_code=200, body=json.dumps(app.current_request.to_dict()))
     else:
@@ -143,7 +143,7 @@ def view_run_route(environ, check, method):
     req_dict = app.current_request.to_dict()
     domain, context = get_domain_and_context(req_dict)
     query_params = req_dict.get('query_params', {})
-    if check_authorization(req_dict):
+    if check_authorization(req_dict, environ):
         if method == 'action':
             return view_run_action(environ, check, query_params, context)
         else:
@@ -159,7 +159,7 @@ def view_route(environ):
     """
     req_dict = app.current_request.to_dict()
     domain, context = get_domain_and_context(req_dict)
-    return view_foursight(environ, check_authorization(req_dict), domain, context)
+    return view_foursight(environ, check_authorization(req_dict, environ), domain, context)
 
 
 @app.route('/view/{environ}/{check}/{uuid}', methods=['GET'])
@@ -169,7 +169,7 @@ def view_check_route(environ, check, uuid):
     """
     req_dict = app.current_request.to_dict()
     domain, context = get_domain_and_context(req_dict)
-    if check_authorization(req_dict):
+    if check_authorization(req_dict, environ):
         return view_foursight_check(environ, check, uuid, True, domain, context)
     else:
         return forbidden_response()
@@ -187,7 +187,7 @@ def history_route(environ, check):
     limit = int(query_params.get('limit', '25')) if query_params else 25
     domain, context = get_domain_and_context(req_dict)
     return view_foursight_history(environ, check, start, limit,
-                                  check_authorization(req_dict), domain, context)
+                                  check_authorization(req_dict, environ), domain, context)
 
 
 @app.route('/checks/{environ}/{check}/{uuid}', methods=['GET'])
@@ -195,7 +195,7 @@ def get_check_with_uuid_route(environ, check, uuid):
     """
     Protected route
     """
-    if check_authorization(app.current_request.to_dict()):
+    if check_authorization(app.current_request.to_dict(), environ):
         return run_get_check(environ, check, uuid)
     else:
         return forbidden_response()
@@ -206,7 +206,7 @@ def get_check_route(environ, check):
     """
     Protected route
     """
-    if check_authorization(app.current_request.to_dict()):
+    if check_authorization(app.current_request.to_dict(), environ):
         return run_get_check(environ, check, None)
     else:
         return forbidden_response()
@@ -224,7 +224,7 @@ def put_check_route(environ, check):
     Protected route
     """
     request = app.current_request
-    if check_authorization(request.to_dict()):
+    if check_authorization(request.to_dict(), environ):
         put_data = request.json_body
         return run_put_check(environ, check, put_data)
     else:
@@ -242,7 +242,7 @@ def put_environment(environ):
     Protected route
     """
     request = app.current_request
-    if check_authorization(request.to_dict()):
+    if check_authorization(request.to_dict(), environ):
         env_data = request.json_body
         return run_put_environment(environ, env_data)
     else:
@@ -254,7 +254,7 @@ def get_environment_route(environ):
     """
     Protected route
     """
-    if check_authorization(app.current_request.to_dict()):
+    if check_authorization(app.current_request.to_dict(), environ):
         return run_get_environment(environ)
     else:
         return forbidden_response()

--- a/tests/test_check_utils.py
+++ b/tests/test_check_utils.py
@@ -169,6 +169,7 @@ class TestCheckUtils():
             assert (isinstance(group['_statuses'], dict))
             assert (len(group.keys()) > 2)
 
+    @pytest.mark.flaky
     def test_run_check_or_action(self):
         test_uuid = datetime.datetime.utcnow().isoformat()
         check = utils.init_check_res(self.connection, 'test_random_nums')


### PR DESCRIPTION
- Change 'check_authorization' in app_utils.py to check admin privileges based on the user group on the relevant portal
- Patch routes in app.py to pass 'environ' to 'check_authorization' so the relevant portal can be resolved
- Test the above functionality (and JWT)
- Add flaky flag to test_run_check_or_action as it failed once when it shouldn't have