### PR TITLE
look at context instead of host

### DIFF
--- a/chalicelib/app_utils.py
+++ b/chalicelib/app_utils.py
@@ -125,10 +125,9 @@ def check_authorization(request_dict, env=None):
     # if we're on localhost, automatically grant authorization
     # this looks bad but isn't because request authentication will
     # still fail if local keys are not configured
-    domain, _ = get_domain_and_context(request_dict)
-    if domain is not None:
-        if 'localhost' in domain:
-            return True
+    src_ip = request_dict.get('context', {}).get('identity', {}).get('sourceIp', '')
+    if src_ip == '127.0.0.1':
+        return True
     token = get_jwt(request_dict)
     auth0_client = os.environ.get('CLIENT_ID', None)
     auth0_secret = os.environ.get('CLIENT_SECRET', None)

--- a/tests/test_app_utils.py
+++ b/tests/test_app_utils.py
@@ -90,9 +90,17 @@ class TestAppUtils():
             with mock.patch('jwt.decode', return_value=payload1):
                 auth = app_utils.check_authorization({}, env='all') # test all
             assert auth
-        with mock.patch('chalicelib.app_utils.get_domain_and_context', return_value=('localhost', '')):
-            auth = app_utils.check_authorization({}, env='all') # local should authenticate
-            assert auth
+        # build a 'request header' that just consists of the context we would expect
+        # to see if authenticating from localhost
+        ctx = {
+            'context': {
+                'identity' : {
+                    'sourceIp': '127.0.0.1'
+                }
+            }
+        }
+        auth = app_utils.check_authorization(ctx, env='all')
+        assert auth
         with mock.patch('chalicelib.app_utils.get_jwt', return_value='token'):
             with mock.patch('jwt.decode', return_value=payload1):
                 auth = app_utils.check_authorization({}, env='data,staging') # test more than one


### PR DESCRIPTION
- For local authentication, look at request context instead of the header, which is very easily modified