### PR TITLE
Fix to check_assay_classification_short_names

### DIFF
--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -1146,7 +1146,8 @@ def check_assay_classification_short_names(connection, **kwargs):
         "context-dependent reporter expression": "Reporter Expression",
         "scanning electron microscopy": "SEM",
         "transmission electron microscopy": "TEM",
-        "immunofluorescence": "Immunofluorescence"
+        "immunofluorescence": "Immunofluorescence",
+        "capture hi-c": "Enrichment Hi-C"
     }
     exptypes = ff_utils.search_metadata('search/?type=ExperimentType&frame=object',
                                         key=connection.ff_keys)
@@ -1156,6 +1157,8 @@ def check_assay_classification_short_names(connection, **kwargs):
         value = ''
         if exptype.get('assay_classification', '').lower() in subclass_dict:
             value = subclass_dict[exptype['assay_classification'].lower()]
+        elif exptype.get('title', '').lower() in subclass_dict:
+            value = subclass_dict[exptype['title'].lower()]
         elif exptype.get('assay_subclassification', '').lower() in subclass_dict:
             value = subclass_dict[exptype['assay_subclassification'].lower()]
         else:


### PR DESCRIPTION
Capture Hi-C recently had it's short name changed to a custom
value, added a fix to this check that makes sure Capture Hi-C
has this value as the assay_subclassification_short property.