### PR TITLE
Check to wipe build indices

### DIFF
--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -1335,5 +1335,16 @@
                 }
             }
         }
+    },
+    "wipe_build_indices" : {
+        "title": "Wipe Build Indicies",
+        "group": "System checks",
+        "schedule": {
+            "morning_checks": {
+                "data": {
+                    "kwargs": {"primary": true}
+                }
+            }
+        }
     }
 }

--- a/chalicelib/checks/system_checks.py
+++ b/chalicelib/checks/system_checks.py
@@ -31,6 +31,7 @@ def wipe_build_indices(connection, **kwargs):
     if full_output['acknowledged'] != True:
         check.status = 'FAIL'
         check.summary = check.description = 'Failed to wipe all test indices, see full output'
+    check.full_output = full_output
     return check
 
 

--- a/chalicelib/checks/system_checks.py
+++ b/chalicelib/checks/system_checks.py
@@ -28,7 +28,7 @@ def wipe_build_indices(connection, **kwargs):
     BUILD_ES = 'search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80'
     client = es_utils.create_es_client(BUILD_ES, True)
     full_output = client.indices.delete(index='*')
-    if full_output['acknowledged'] != 'true':
+    if full_output['acknowledged'] != True:
         check.status = 'FAIL'
         check.summary = check.description = 'Failed to wipe all test indices, see full output'
     return check

--- a/chalicelib/checks/system_checks.py
+++ b/chalicelib/checks/system_checks.py
@@ -20,6 +20,21 @@ import time
 
 
 @check_function()
+def wipe_build_indices(connection, **kwargs):
+    """ Wipes all indices on the FF-Build ES env """
+    check = CheckResult(connection, 'wipe_build_indices')
+    check.status = 'PASS'
+    check.summary = check.description = 'Wiped all test indices'
+    BUILD_ES = 'search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80'
+    client = es_utils.create_es_client(BUILD_ES, True)
+    full_output = client.indices.delete(index='*')
+    if full_output['acknowledged'] != 'true':
+        check.status = 'FAIL'
+        check.summary = check.description = 'Failed to wipe all test indices, see full output'
+    return check
+
+
+@check_function()
 def elastic_search_space(connection, **kwargs):
     """ Checks that our ES nodes all have a certain amount of space remaining """
     check = CheckResult(connection, 'elastic_search_space')

--- a/docs/source/development_tips.rst
+++ b/docs/source/development_tips.rst
@@ -22,7 +22,7 @@ Manual testing of your check
 
 Let's assume that you've already finished steps 1 through 3 in the list above (these are pretty much covered in the getting started and checks documentation). For step 4, it is recommended that you go into a local Python interpreter and run your check directly to ensure that it provides the output you want. Below is some code run from the root directory of this project that will outline manual testing of the ``items_created_in_the_past_day`` check contained within the ``wrangler_checks`` check module. The code below is run from the Python interpreter.
 
-.. code-block::
+.. code-block:: python
 
    >>> import app
    # create a Foursight connection to the 'mastertest' environment
@@ -44,7 +44,7 @@ It's important to note that if you return the ``check`` at the end of your funct
 
 To overwrite the primary check result, you must set the ``primary=True`` key word argument for your check. If you want to, you can pass this dictionary into the ``run_check_or_action`` function:
 
-.. code-block::
+.. code-block:: python
 
    # will overwrite the latest result for items_created_in_the_past_day, which won't display on the UI
    app.run_check_or_action(connection, 'wrangler_checks/items_created_in_the_past_day', {})
@@ -61,6 +61,11 @@ The Foursight UI is also a useful place to test your checks, since it is very ea
 
 Just make sure to do your testing on the development stage of Foursight, which you can deploy to locally using ``python -m deploy dev``. Please keep in mind that you will need to have some environment variables locally to make this work.
 
+Automated Check Testing
+^^^^^^^^^^^^^^^^^^^^^^^
+
+In the below section we document some code on how to test out a Foursight check in the Python interpreter. We've also provided a script in the top level ``scripts`` directory that will automate this process. If you `cd` into the script directory and run ``python test_check.py`` some help on how to use it will appear.
+
 Manual testing of your action
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -70,7 +75,7 @@ Actions function very similarly to checks when run individually. In fact, testin
 
 **WARNING:** when manually running an action, be aware that it actually be executed on the given Foursight connection. For that reason, when in testing stages it is best to remove any impactful code within an action or insert a break point to have manual control.
 
-.. code-block::
+.. code-block:: python
 
    >>> import app
    # create a Foursight connection to the 'mastertest' environment
@@ -90,7 +95,7 @@ Let's say you want to run a whole schedule and not an individual check. To test 
 
 **NOTE:** if a check setup has kwargs including ``primary=True``\ , then the result will be written live to the Foursight UI. Omitting this argument when testing your check may be desirable.
 
-.. code-block::
+.. code-block:: python
 
    >>> import app
    # queue_scheduled_checks takes the environment name directly (not connection)
@@ -111,7 +116,7 @@ Scheduling your checks
 
 Okay, so you've written a check function and want to make a new schedule for it. To schedule it using a CRON or rate expression, go to the top of app.py and create a new scheduled function (leading with the ``@app.schedule()`` decorator). Two examples are below:
 
-.. code-block::
+.. code-block:: python
 
    @app.schedule(Rate(1, unit=Rate.HOURS))
    def one_hour_checks(event):
@@ -120,7 +125,7 @@ Okay, so you've written a check function and want to make a new schedule for it.
 
 Or scheduling with a CRON expression... for more info, `see here <http://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html>`_.
 
-.. code-block::
+.. code-block:: python
 
    # run at 10 am UTC every day
    @app.schedule(Cron(0, 10, '*', '*', '?', '*'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ geocoder==1.38.1
 fuzzywuzzy==0.17.0
 elasticsearch==5.5.3
 elasticsearch-dsl==5.3.0
+python-Levenshtein==0.12.0

--- a/scripts/test_check.py
+++ b/scripts/test_check.py
@@ -1,0 +1,64 @@
+import sys
+import datetime
+import boto3
+import json
+import argparse
+sys.path.append('..')
+import app
+
+EPILOG = __doc__
+ENVS = ['mastertest', 'hotseat', 'webdev', 'staging', 'cgap', 'data']
+STAGES = ['dev', 'prod']
+
+
+def setup_stage(stage):
+    if not stage:
+        app.set_stage('dev')
+    else:
+        if stage not in STAGES:
+            print('Bad stage')
+            exit(1)
+        else:
+            app.set_stage(args.stage)
+
+
+def setup_env(env):
+    if not env:
+        connection = app.init_connection('mastertest')
+    else:
+        if env not in ENVS:
+            print('Bad env')
+            exit(1)
+        try:
+            connection = app.init_connection(args.env)
+        except:
+            print('Could not establish connection to env: %s' % args.env)
+            exit(1)
+    return connection
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Tests a check/action',
+        epilog=EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument('check', help='full check name')
+    parser.add_argument('--env', help='env name, mastertest by default')
+    parser.add_argument('--stage', help='stage, dev or prod, dev by default')
+    args = parser.parse_args()
+
+    setup_stage(args.stage)
+    connection = setup_env(args.env)
+
+    # run the check
+    # XXX: Configure using kwargs?
+    try:
+        res = app.run_check_or_action(connection, args.check, {})
+    except:
+        print('Failed to execute check name: %s' % args.check)
+        exit(1)
+    print(res)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Implements a check that runs daily to wipe all indices on the FF-builds ES instance. These indices are normally cleaned up by the Travis build but it is possible if the build errors that these indices will remain. This check will wipe them.
- Adds `test_check.py` script to the script directory. Provides a quick and easy interface for testing checks that will hopefully be useful to others.
- Fix docs so code blocks render correctly, add line about the above mentioned script.