### PR TITLE
Check idx higlass

### DIFF
--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -706,6 +706,7 @@ def check_expsets_processedfiles_for_modified_higlass_items(connection, **kwargs
     env = connection.ff_env
     indexing_queue = ff_utils.stuff_in_queues(env, check_secondary=True)
     if indexing_queue:
+        check = CheckResult(connection, 'check_expsets_processedfiles_for_modified_higlass_items')
         check.status = 'PASS'  # maybe use warn?
         check.brief_output = ['Waiting for indexing queue to clear']
         check.summary = 'Waiting for indexing queue to clear'

--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -703,6 +703,15 @@ def check_expsets_processedfiles_for_modified_higlass_items(connection, **kwargs
         Returns:
             check result object.
     """
+    env = connection.ff_env
+    indexing_queue = ff_utils.stuff_in_queues(env, check_secondary=True)
+    if indexing_queue:
+        check.status = 'PASS'  # maybe use warn?
+        check.brief_output = ['Waiting for indexing queue to clear']
+        check.summary = 'Waiting for indexing queue to clear'
+        check.full_output = {}
+        return check
+
     return find_expsets_processedfiles_requiring_higlass_items(
         connection,
         check_name="check_expsets_processedfiles_for_modified_higlass_items",


### PR DESCRIPTION
- check_expsets_processedfiles_for_modified_higlass_items now checks indexing_queue before doing anything.
- will prevent check/action being run while release script is running, which previously resulted in status mismatches
- no other higlass checks modified, because this was the only one observed to cause problems