### PR TITLE
Mod biorxiv chk

### DIFF
--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -458,6 +458,10 @@
                 "staging": {
                     "kwargs": {"primary": true},
                     "dependencies": []
+                },
+                "hotseat": {
+                    "kwargs": {"primary": true},
+                    "dependencies": []
                 }
             }
         }

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -458,10 +458,6 @@
                 "staging": {
                     "kwargs": {"primary": true},
                     "dependencies": []
-                },
-                "hotseat": {
-                    "kwargs": {"primary": true},
-                    "dependencies": []
                 }
             }
         }

--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -137,7 +137,6 @@ def biorxiv_is_now_published(connection, **kwargs):
     # see if a 'manual' mapping was provided as a parameter
     fndcnt = 0
     if kwargs.get('add_to_result'):
-        import pdb; pdb.set_trace()
         b2p = [pair.strip().split(' ') for pair in kwargs.get('add_to_result').split(',')]
         fulloutput['biorxivs2check'].update({b.strip(): [p.strip()] for b, p in b2p})
         fndcnt = len(b2p)


### PR DESCRIPTION
Modified biorxiv2replace check with kwarg 'add_result' that takes a uuid PMID:nnnn pair or pairs (comma separated pairs) to add to the check result so they can be acted on by the action.

Temporarily added schedule to hotseat for testing purposes - should remove before merging.