### PR TITLE
higlass update check should now patch existing viewconf if present

### DIFF
--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -1278,6 +1278,7 @@ def find_expsets_otherprocessedfiles_requiring_higlass_items(connection, check_n
                         "genome_assembly": fil["genome_assembly"],
                         "files": [],
                         "type": filegroup["type"],
+                        "higlass_item_uuid": filegroup.get('higlass_view_config', {}).get('uuid')
                     }
 
                 # add file accessions to this group


### PR DESCRIPTION
Currently, there's a check for higlass triggering over and over again because its finding experiment sets that were last updated after the last time the higlass action was run, although this seems to be due to indexing delay. The purpose of this PR is to allow cases where higlass_view_confs are only updated, to happen without patching/modifying the experiment set.