### PR TITLE
Tweak to biofeature organism check 

### DIFF
--- a/chalicelib/checks/audit_checks.py
+++ b/chalicelib/checks/audit_checks.py
@@ -693,7 +693,10 @@ def check_bio_feature_organism_name(connection, **kwargs):
         else:
             if linked_orgn_name:
                 if orgn_name != linked_orgn_name:
-                    if linked_orgn_name == 'unspecified':
+                    if linked_orgn_name == 'unspecified' or orgn_name == 'engineered reagent':
+                        # unspecified here means an organism or multiple coule not be found from linked genes or other criteria
+                        # for engineered reagent may find a linked name depending on what is linked to bio_feature
+                        # usually want to keep the given 'engineered reagent' label but warrants occasional review
                         name_trumps_guess += 1
                         to_report['name_trumps_guess'].update({bfuuid: (orgn_name, linked_orgn_name)})
                     elif orgn_name == 'unspecified':  # patch if a specific name is found
@@ -708,6 +711,7 @@ def check_bio_feature_organism_name(connection, **kwargs):
                     matches += 1
             else:
                 to_report['name_trumps_guess'].update({bfuuid: (orgn_name, None)})
+                name_trumps_guess += 1
     brief_report.sort()
     cnt_rep = [
         'MATCHES: {}'.format(matches),

--- a/docs/source/development_tips.rst
+++ b/docs/source/development_tips.rst
@@ -25,6 +25,9 @@ Let's assume that you've already finished steps 1 through 3 in the list above (t
 .. code-block:: python
 
    >>> import app
+   # set the stage for foursight - currently 'dev' is the default
+   # NOTE: you probably want to change this to 'prod' to get a result posted to s3 (see below)
+   >>> app.set_stage('prod')
    # create a Foursight connection to the 'mastertest' environment
    >>> connection = app.init_connection('mastertest')
    # run your check using the run_check_or_action utility


### PR DESCRIPTION
1. engineered reagent is the preferred organism even if another is found in linked genes or genomic regions etc. 
2. these cases are added to the full report to be reviewed occasionally - being put into the name trumps guess bucket
3. another small tweak to ensure that the name trumps guess cases are counted as ok mismatches.