### PR TITLE
added more specific code for handling markdown links

### DIFF
--- a/chalicelib/checks/audit_checks.py
+++ b/chalicelib/checks/audit_checks.py
@@ -344,11 +344,15 @@ def check_help_page_urls(connection, **kwargs):
         body = result.get('body', '')
         urls = []
         if result.get('options', {}).get('filetype') == 'md':
+            # look for markdown links - e.g. [text](link)
             links = re.findall('\[[^\]]+\]\([^\)]+\)', body)
             for link in links:
+                # test only link part of match (not text part, even if it looks like a link)
                 idx = link.index(']')
                 url = link[link.index('(', idx)+1:-1]
+                # remove these from body so body can be checked for other types of links
                 body = body[:body.index(link)] + body[body.index(link)+len(link):]
+        # looks for links starting with http (full) or / (relative) inside parentheses or brackets
         urls += re.findall('[\(|\[|=]["]*(http[^\s\)\]]+|/[^\s\)\]]+)[\)|\]|"]', body)
         for url in urls:
             if url.startswith('mailto'):


### PR DESCRIPTION
More handling of links:
- if page is markdown, looks for markdown links (e.g. [text](link)) and ignores the text part
- checks sections (relative links that start with #) 
- excludes mailto links