### PR TITLE
Use utils 0.10.0 to fix C4-95

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,12 @@ htmlcov/
 coverage.xml
 *.ipynb
 !*LocalTest.ipynb
+
+# Virtual environments
+*env/
+
+# Emacs
+*~
+
+# PyCharm
+.idea/

--- a/poetry.lock
+++ b/poetry.lock
@@ -145,7 +145,7 @@ description = "Utility package for interacting with the 4DN Data Portal and othe
 name = "dcicutils"
 optional = false
 python-versions = ">=3.4,<3.7"
-version = "0.9.6"
+version = "0.10.0"
 
 [package.dependencies]
 aws-requests-auth = ">=0.4.2,<1"
@@ -317,7 +317,7 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.5.0"
+version = "1.5.1"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -641,7 +641,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "a1ca674cfb804b1d934a89b6165a1d2b3ce9f906022c29fb1f3b68942feed97f"
+content-hash = "685c9cad52763badad361a152a3e539c5dafd4828783cd7de65aaf9537b390d7"
 python-versions = ">=3.6,<3.7"
 
 [metadata.files]
@@ -722,8 +722,8 @@ coverage = [
     {file = "coverage-5.0.4.tar.gz", hash = "sha256:1b60a95fc995649464e0cd48cecc8288bac5f4198f21d04b8229dc4097d76823"},
 ]
 dcicutils = [
-    {file = "dcicutils-0.9.6-py3-none-any.whl", hash = "sha256:451dd299f81f6592ce445d03d0abe90369ac33009512443dd2c1c657c0a8f7eb"},
-    {file = "dcicutils-0.9.6.tar.gz", hash = "sha256:87ed154c57cac821e2948a8375718952c8837287421a8ba7f63e56eaa2506a7d"},
+    {file = "dcicutils-0.10.0-py3-none-any.whl", hash = "sha256:fdddf246cd672aa3d5409df1ebaed962764ccc50d6c38412dd00ce344e81cf59"},
+    {file = "dcicutils-0.10.0.tar.gz", hash = "sha256:12902d9cbf0559b714a2e5239e8560cce291942c11d0b81d1b3e00358538e27a"},
 ]
 decorator = [
     {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
@@ -782,8 +782,8 @@ idna = [
     {file = "idna-2.9.tar.gz", hash = "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.5.0-py2.py3-none-any.whl", hash = "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"},
-    {file = "importlib_metadata-1.5.0.tar.gz", hash = "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302"},
+    {file = "importlib_metadata-1.5.1-py2.py3-none-any.whl", hash = "sha256:0095bf45caca7a93685cbb9e5ef49f0ed37f848639df8f4684f07229aa7a8322"},
+    {file = "importlib_metadata-1.5.1.tar.gz", hash = "sha256:dd381cddc02a58a23667ef675164ad70848d82966d3a8fddea96dcfb51064803"},
 ]
 jinja2 = [
     {file = "Jinja2-2.10.1-py2.py3-none-any.whl", hash = "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -641,7 +641,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "ebf26821b208c9df571cbb4034124d505028e421440453b3278a707fb3167501"
+content-hash = "a1ca674cfb804b1d934a89b6165a1d2b3ce9f906022c29fb1f3b68942feed97f"
 python-versions = ">=3.6,<3.7"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.6,<3.7"
-dcicutils = ">=0.9.6,<1"
+dcicutils = ">=0.10.0,<1"
 click = "6.7"
 PyJWT = "1.5.3"
 Jinja2 = "2.10.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.6,<3.7"
-dcicutils = "0.9.6"
+dcicutils = ">=0.9.6,<1"
 click = "6.7"
 PyJWT = "1.5.3"
 Jinja2 = "2.10.1"


### PR DESCRIPTION
This tries to pull in better handling in utils (version `0.10.0`) for managing fourfront prod environments in order to fix bug [C4-95](https://hms-dbmi.atlassian.net/browse/C4-95).

As an incidental matter, I'm also making two other changes:

* Adjust to depend on `dcicutils` version `>=0.10.0,<1` rather than just `0.10.0`.
* Adjust `.gitignore` to better support PyCharm, Emacs, and virtual environments.