### PR TITLE
Some issues relating to env_utils use, and a fix to google api (C4-95 leftovers)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .chalice/config.json
 *.pyc
 __pycache__
+*.egg-info/
 .coverage
 *.DS_Store
 htmlcov/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: test
+
+configure:  # does any pre-requisite installs
+	pip install poetry
+
+build:  # builds
+	make configure
+	poetry install
+
+test:
+	pytest -vv --cov chalicelib tests
+
+info:
+	@: $(info Here are some 'make' options:)
+	   $(info - Use 'make configure' to install poetry, though 'make build' will do it automatically.)
+	   $(info - Use 'make build' to install dependencies using poetry.)
+	   $(info - Use 'make test' to run tests with the normal options we use on travis)

--- a/chalicelib/checks/helpers/cgap_utils.py
+++ b/chalicelib/checks/helpers/cgap_utils.py
@@ -459,7 +459,7 @@ def run_missing_wfr(input_json, input_files, run_name, auth, env):
         "env": env,
         "run_type": input_json['app_name'],
         "run_id": run_name}
-    # input_json['env_name'] = 'fourfront-cgap'
+    # input_json['env_name'] = CGAP_ENV_WEBPROD  # e.g., 'fourfront-cgap'
     input_json['step_function_name'] = 'tibanna_zebra'
     # input_json['public_postrun_json'] = True
     try:

--- a/chalicelib/checks/helpers/google_utils.py
+++ b/chalicelib/checks/helpers/google_utils.py
@@ -10,7 +10,8 @@ from datetime import (
 from types import FunctionType
 from calendar import monthrange
 from collections import OrderedDict
-from apiclient.discovery import build
+from dcicutils.env_utils import FF_PROD_BUCKET_ENV
+from googleapiclient.discovery import build
 from google.oauth2.service_account import Credentials
 from dcicutils import (
     ff_utils,
@@ -65,9 +66,8 @@ class GoogleAPISyncer:
     Arguments:
         ff_access_keys      - Optional. A dictionary with a 'key', 'secret', and 'server', identifying admin account access keys and FF server to POST to.
         google_api_key      - Optional. Override default API key for accessing Google.
-        s3UtilsInstance     - Optional. Provide an S3Utils class instance which is connecting to `fourfront-webprod` fourfront environment in order
-                              to obtain proper Google API key (if none supplied otherwise).
-                              If not supplied, a new S3 connection will be created to `fourfront-webprod`.
+        s3UtilsInstance     - Optional. Provide an S3Utils class instance connected to a bucket with a proper Google API key (if none supplied otherwise).
+                              If not supplied, a new S3 connection will be created to the Fourfront production bucket.
         extra_config        - Additional Google API config, e.g. OAuth2 scopes and Analytics View ID. Shouldn't need to set this.
     '''
 
@@ -95,7 +95,7 @@ class GoogleAPISyncer:
     ):
         '''Authenticate with Google APIs and initialize sub-class instances.'''
         if s3UtilsInstance is None:
-            self._s3Utils = s3_utils.s3Utils(env="fourfront-webprod") # Google API Keys are stored on production bucket only ATM.
+            self._s3Utils = s3_utils.s3Utils(env=FF_PROD_BUCKET_ENV) # Google API Keys are stored on production bucket only ATM.
         else:
             self._s3Utils = s3UtilsInstance
 

--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -5,6 +5,7 @@ from ..utils import (
 )
 from ..run_result import CheckResult, ActionResult
 from dcicutils import ff_utils
+from dcicutils.env_utils import FF_PROD_BUCKET_ENV
 import re
 import requests
 import json
@@ -1402,7 +1403,7 @@ def patch_states_files_higlass_defaults(connection, **kwargs):
     total_patches = check_res['full_output']['to_add']
 
     s3 = boto3.resource('s3')
-    bucket = s3.Bucket('elasticbeanstalk-fourfront-webprod-files')
+    bucket = s3.Bucket('elasticbeanstalk-%s-files' % FF_PROD_BUCKET_ENV)
 
     query = '/search/?type=FileReference'
     all_ref_files = ff_utils.search_metadata(query, key=connection.ff_keys)

--- a/chalicelib/fs_connection.py
+++ b/chalicelib/fs_connection.py
@@ -13,6 +13,10 @@ class FSConnection(object):
     - ff_server: string server name of the linked FF
     - ff_env: string EB enviroment name of FF (such as 'fourfront-webprod').
               This is kept up-to-date for data and staging
+              (COMPATIBILITY NOTE: This argument is mis-named.
+               It isn't really an ff_env but rather an s3 bucket key,
+               so 'fourfront-webprod' still names the bucket used
+               by environment 'fourfront-blue' and 'fourfront-green'.)
     - ff_s3: s3Utils connection to the FF environment (see dcicutils.s3_utils)
     - ff_keys: FF keys for the environment with 'key', 'secret' and 'server'
     - ff_es: string server of the elasticsearch for the FF

--- a/poetry.lock
+++ b/poetry.lock
@@ -37,10 +37,10 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = "*"
-version = "1.12.33"
+version = "1.12.36"
 
 [package.dependencies]
-botocore = ">=1.15.33,<1.16.0"
+botocore = ">=1.15.36,<1.16.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
@@ -50,7 +50,7 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = "*"
-version = "1.15.33"
+version = "1.15.36"
 
 [package.dependencies]
 docutils = ">=0.10,<0.16"
@@ -75,7 +75,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2019.11.28"
+version = "2020.4.5.1"
 
 [[package]]
 category = "dev"
@@ -145,7 +145,7 @@ description = "Utility package for interacting with the 4DN Data Portal and othe
 name = "dcicutils"
 optional = false
 python-versions = ">=3.4,<3.7"
-version = "0.13.0"
+version = "0.13.2"
 
 [package.dependencies]
 aws-requests-auth = ">=0.4.2,<1"
@@ -273,7 +273,7 @@ description = "Google Authentication Library"
 name = "google-auth"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
-version = "1.12.0"
+version = "1.13.1"
 
 [package.dependencies]
 cachetools = ">=2.0.0,<5.0"
@@ -300,7 +300,7 @@ description = "A comprehensive HTTP client library."
 name = "httplib2"
 optional = false
 python-versions = "*"
-version = "0.17.0"
+version = "0.17.1"
 
 [[package]]
 category = "main"
@@ -438,7 +438,7 @@ description = "Python parsing module"
 name = "pyparsing"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.6"
+version = "2.4.7"
 
 [[package]]
 category = "dev"
@@ -641,7 +641,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "685c9cad52763badad361a152a3e539c5dafd4828783cd7de65aaf9537b390d7"
+content-hash = "132b67a35a3c816f739a06bbe13d12e406519a839ef589defa8939b82342d564"
 python-versions = ">=3.6,<3.7"
 
 [metadata.files]
@@ -657,20 +657,20 @@ aws-requests-auth = [
     {file = "aws-requests-auth-0.4.2.tar.gz", hash = "sha256:112c85fe938a01e28f7e1a87168615b6977b28596362b1dcbafbf4f2cc69f720"},
 ]
 boto3 = [
-    {file = "boto3-1.12.33-py2.py3-none-any.whl", hash = "sha256:6f239e3798a1e4d5c9a8093b80c85110d1f872d4f61ea348aa89269b14da186f"},
-    {file = "boto3-1.12.33.tar.gz", hash = "sha256:ad774b0e98d093ae425b85fdb25e5ae70a02ebe036c4222e1b93444699719221"},
+    {file = "boto3-1.12.36-py2.py3-none-any.whl", hash = "sha256:57397f9ad3e9afc17e6100a38c6e631b6545aabc7f8c38b86ff2c6f5931d0ebf"},
+    {file = "boto3-1.12.36.tar.gz", hash = "sha256:911994ef46595e8ab9f08eee6b666caea050937b96d54394292e958330cd7ad5"},
 ]
 botocore = [
-    {file = "botocore-1.15.33-py2.py3-none-any.whl", hash = "sha256:4240f2fb38c4cccc0fd319e6620a30a1c19b869c1e33ff864eec9cde7965a6ba"},
-    {file = "botocore-1.15.33.tar.gz", hash = "sha256:078a9731e054f9ee914a8eac77e445de3c1344a00d7eebfee9cae7f40b7f48e8"},
+    {file = "botocore-1.15.36-py2.py3-none-any.whl", hash = "sha256:d2233e19b6a60792185b15fe4cd8f92c5579298e5079daf17f66f6e639585e3a"},
+    {file = "botocore-1.15.36.tar.gz", hash = "sha256:5fc5e8629b5375d591a47d05baaff6ccdf5c3b617aad1e14286be458092c9e53"},
 ]
 cachetools = [
     {file = "cachetools-4.0.0-py3-none-any.whl", hash = "sha256:b304586d357c43221856be51d73387f93e2a961598a9b6b6670664746f3b6c6c"},
     {file = "cachetools-4.0.0.tar.gz", hash = "sha256:9a52dd97a85f257f4e4127f15818e71a0c7899f121b34591fcc1173ea79a0198"},
 ]
 certifi = [
-    {file = "certifi-2019.11.28-py2.py3-none-any.whl", hash = "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3"},
-    {file = "certifi-2019.11.28.tar.gz", hash = "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"},
+    {file = "certifi-2020.4.5.1-py2.py3-none-any.whl", hash = "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304"},
+    {file = "certifi-2020.4.5.1.tar.gz", hash = "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"},
 ]
 chalice = [
     {file = "chalice-1.11.1-py2.py3-none-any.whl", hash = "sha256:23e516a3aed811f9d7d56b1e52060f71791e0a11d0bddc7e19784d18c7276aa3"},
@@ -722,8 +722,8 @@ coverage = [
     {file = "coverage-5.0.4.tar.gz", hash = "sha256:1b60a95fc995649464e0cd48cecc8288bac5f4198f21d04b8229dc4097d76823"},
 ]
 dcicutils = [
-    {file = "dcicutils-0.13.0-py3-none-any.whl", hash = "sha256:5b2b5c9ce22ad1ac3c4f7323a9fc2000e0a22b30722fa01c560b491010a6450f"},
-    {file = "dcicutils-0.13.0.tar.gz", hash = "sha256:d1b14cf703f55cd54cec369a100de5c1e02a7fb0be8dacc3fe7b41b2e178762c"},
+    {file = "dcicutils-0.13.2-py3-none-any.whl", hash = "sha256:ad2f760e4630937b9b180b482d0a64c4e9c2a3e893d18dd0ac26fea6403b5dec"},
+    {file = "dcicutils-0.13.2.tar.gz", hash = "sha256:5085f52b2bacab9a98c3adbfcc3dce4adb1a0cd5265b49df4411aaf13beb5d72"},
 ]
 decorator = [
     {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
@@ -766,16 +766,16 @@ google-api-python-client = [
     {file = "google_api_python_client-1.7.4-py3-none-any.whl", hash = "sha256:7cc47cf80b25ecd7f3d917ea247bb6c62587514e40604ae29c47c0e4ebd1174b"},
 ]
 google-auth = [
-    {file = "google-auth-1.12.0.tar.gz", hash = "sha256:016924388770b7e66c7e9ade1c4c3144ee88812d79697fd6c0dad9abdfcda2fd"},
-    {file = "google_auth-1.12.0-py2.py3-none-any.whl", hash = "sha256:01d686448f57d3bc027726474faa1aa650ba333bedb392e06938b0add8ec8d3a"},
+    {file = "google-auth-1.13.1.tar.gz", hash = "sha256:a5ee4c40fef77ea756cf2f1c0adcf475ecb53af6700cf9c133354cdc9b267148"},
+    {file = "google_auth-1.13.1-py2.py3-none-any.whl", hash = "sha256:cab6c707e6ee20e567e348168a5c69dc6480384f777a9e5159f4299ad177dcc0"},
 ]
 google-auth-httplib2 = [
     {file = "google-auth-httplib2-0.0.3.tar.gz", hash = "sha256:098fade613c25b4527b2c08fa42d11f3c2037dda8995d86de0745228e965d445"},
     {file = "google_auth_httplib2-0.0.3-py2.py3-none-any.whl", hash = "sha256:f1c437842155680cf9918df9bc51c1182fda41feef88c34004bd1978c8157e08"},
 ]
 httplib2 = [
-    {file = "httplib2-0.17.0-py3-none-any.whl", hash = "sha256:79751cc040229ec896aa01dced54de0cd0bf042f928e84d5761294422dde4454"},
-    {file = "httplib2-0.17.0.tar.gz", hash = "sha256:de96d0a49f46d0ee7e0aae80141d37b8fcd6a68fb05d02e0b82c128592dd8261"},
+    {file = "httplib2-0.17.1-py3-none-any.whl", hash = "sha256:4e26d60a6b37ff0e8401e976f13667cb3746dfa1b50833003b7f138042b54247"},
+    {file = "httplib2-0.17.1.tar.gz", hash = "sha256:b81b2cd2248285168a4359f2acf24521a4099b5853e790309c45dcb90ee4b3c6"},
 ]
 idna = [
     {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
@@ -847,8 +847,8 @@ pyjwt = [
     {file = "PyJWT-1.5.3.tar.gz", hash = "sha256:500be75b17a63f70072416843dc80c8821109030be824f4d14758f114978bae7"},
 ]
 pyparsing = [
-    {file = "pyparsing-2.4.6-py2.py3-none-any.whl", hash = "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"},
-    {file = "pyparsing-2.4.6.tar.gz", hash = "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f"},
+    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
+    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
     {file = "pytest-5.1.2-py3-none-any.whl", hash = "sha256:95d13143cc14174ca1a01ec68e84d76ba5d9d493ac02716fd9706c949a505210"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "0.9.0"
+version = "0.9.1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN Team <william_ronchetti@hms.harvard.edu>"]
 license = "MIT"
@@ -10,7 +10,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.6,<3.7"
-dcicutils = ">=0.13.0,<1"
+dcicutils = ">=0.13.2,<1"
 click = "6.7"
 PyJWT = "1.5.3"
 Jinja2 = "2.10.1"


### PR DESCRIPTION
I did an audit of foursight to make sure it was using dcicutils.env_utils where it could. Mostly things are in order. 

I adjusted a doc string to avoid reference to webprod so that it's not a maintenance issue, but I noticed an issue in the argument named ff_env, which really isn't connecting to fourfront as a site but as an x3 bucket, and our naming isn't consistent so there is some confusion. This is in FSConnection, where perhaps we should rename the `ff_env` that is mentioned there to be `ff_bucket_env` or some such thing like that. Anyway, I mostly mention that for discussion. I wouldn't do it in this PR.

There was a reference to `apiclient.discovery` in the chalicelib helper code that PyCharm felt needed to be `googleapiclient.discovery`. This had nothing to do with `env_utils` but seemed likely to fail, so I fixed that.

