### PR TITLE
Fix registration of Higlass files

### DIFF
--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -1864,6 +1864,7 @@ def patch_file_higlass_uid(connection, **kwargs):
 
             # Based on the filetype, construct a payload to upload to the higlass server.
             payload = {}
+            payload['coordSystem'] = hit['genome_assembly']
             if ftype == 'chromsizes':
                 payload["filepath"] = connection.ff_s3.raw_file_bucket + "/" + hit['upload_key']
                 payload['filetype'] = 'chromsizes-tsv'


### PR DESCRIPTION
When registering Higlass files via foursight, the genome assembly is currently not sent to the Higlass server. As a result all registered files lack the "coordSystem" property, which leads to missing chrom sizes files and a broken genome position search box in Higlass displays on the portal. This PR fixes this.