### PR TITLE
badge messages no longer non-unique

### DIFF
--- a/chalicelib/checks/badge_checks.py
+++ b/chalicelib/checks/badge_checks.py
@@ -208,6 +208,7 @@ def yellow_flag_biosamples(connection, **kwargs):
         if 'HAP-1' in result.get('biosource_summary') and not ploidy:
             messages.append('HAP-1 biosample missing ploidy authentication')
         if messages:
+            messages = [messages[i] for i in range(len(messages)) if messages[i] not in messages[:i]]
             if result.get('status') in REV:
                 check.brief_output[REV_KEY].append('{} missing {}'.format(
                     result['@id'], ', '.join(list(set([item[item.index('missing') + 8:] for item in messages])))


### PR DESCRIPTION
Changed one line in `badge_checks/yellow_flag_biosamples` to remove non-unique items from `messages` list, which can result from a biosample being connected to several BCC items. One line was added, and it was written this way instead of `list(set(messages))` so that the original order would be kept and thus the check won't flag biosamples with a badge already that has messages in a different order.