### PR TITLE
C4-58 Deployment Checks

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,12 @@ DEFAULT_ENV = 'data'
 
 '''######### SCHEDULED FXNS #########'''
 
+
+def effectively_never():
+    """Every February 31st, a.k.a. 'never'."""
+    return Cron('0', '0', '31', '2', '?', '?')
+
+
 # this dictionary defines the CRON schedules for the dev and prod foursight
 # stagger them to reduce the load on Fourfront. Times are UTC
 # info: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
@@ -28,7 +34,7 @@ foursight_cron_by_schedule = {
         'morning_checks_2': Cron('15', '10', '*', '*', '?', '*'),
         'monday_checks': Cron('0', '9', '?', '*', '2', '*'),
         'monthly_checks': Cron('0', '9', '1', '*', '?', '*'),
-        'manual_checks': Cron('0', '0', '31', '2', '?', '?')  # every February 31st aka never
+        'manual_checks': effectively_never()
     },
     'dev': {
         'ten_min_checks': Cron('5/10', '*', '*', '*', '?', '*'),
@@ -40,7 +46,7 @@ foursight_cron_by_schedule = {
         'morning_checks_2': Cron('45', '10', '*', '*', '?', '*'),
         'monday_checks': Cron('30', '9', '?', '*', '2', '*'),
         'monthly_checks': Cron('30', '9', '1', '*', '?', '*'),
-        'manual_checks': Cron('0', '0', '31', '2', '?', '?')
+        'manual_checks': effectively_never()
     }
 }
 
@@ -88,6 +94,11 @@ def monday_checks(event):
 @app.schedule(foursight_cron_by_schedule[STAGE]['monthly_checks'])
 def monthly_checks(event):
     queue_scheduled_checks('all', 'monthly_checks')
+
+
+@app.schedule(foursight_cron_by_schedule[STAGE]['manual_checks'])
+def manual_checks(event):  # should have no effect since cron schedule will never run
+    queue_scheduled_checks('all', 'manual_checks')
 
 
 '''######### END SCHEDULED FXNS #########'''

--- a/app.py
+++ b/app.py
@@ -27,7 +27,8 @@ foursight_cron_by_schedule = {
         'morning_checks': Cron('0', '10', '*', '*', '?', '*'),
         'morning_checks_2': Cron('15', '10', '*', '*', '?', '*'),
         'monday_checks': Cron('0', '9', '?', '*', '2', '*'),
-        'monthly_checks': Cron('0', '9', '1', '*', '?', '*')
+        'monthly_checks': Cron('0', '9', '1', '*', '?', '*'),
+        'manual_checks': Cron('0', '0', '31', '2', '?', '?')  # every February 31st aka never
     },
     'dev': {
         'ten_min_checks': Cron('5/10', '*', '*', '*', '?', '*'),
@@ -38,7 +39,8 @@ foursight_cron_by_schedule = {
         'morning_checks': Cron('30', '10', '*', '*', '?', '*'),
         'morning_checks_2': Cron('45', '10', '*', '*', '?', '*'),
         'monday_checks': Cron('30', '9', '?', '*', '2', '*'),
-        'monthly_checks': Cron('30', '9', '1', '*', '?', '*')
+        'monthly_checks': Cron('30', '9', '1', '*', '?', '*'),
+        'manual_checks': Cron('0', '0', '31', '2', '?', '?')
     }
 }
 

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -1562,19 +1562,40 @@
     "indexer_server_status": {
         "title": "Indexer Server Status",
         "group": "Deployment Checks",
-        "schedule": {},
-        "display": ["data"]
+        "schedule": {
+            "manual_checks": {
+                "data": {
+                    "kwargs": {
+                        "primary": true
+                    }
+                }
+            }
+        }
     },
     "provision_indexer_environment": {
         "title": "Provision Indexer Environment",
         "group": "Deployment Checks",
-        "schedule": {},
-        "display": ["data"]
+        "schedule": {
+            "manual_checks": {
+                "data": {
+                    "kwargs": {
+                        "primary": true
+                    }
+                }
+            }
+        }
     },
     "deploy_application_to_beanstalk": {
         "title": "Deploy Version to ElasticBeanstalk",
         "group": "Deployment Checks",
-        "schedule": {},
-        "display": ["data"]
+        "schedule": {
+            "manual_checks": {
+                "data": {
+                    "kwargs": {
+                        "primary": true
+                    }
+                }
+            }
+        }
     }
 }

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -1558,5 +1558,23 @@
                 }
             }
         }
+    },
+    "indexer_server_status": {
+        "title": "Indexer Server Status",
+        "group": "Deployment Checks",
+        "schedule": {},
+        "display": ["data"]
+    },
+    "provision_indexer_environment": {
+        "title": "Provision Indexer Environment",
+        "group": "Deployment Checks",
+        "schedule": {},
+        "display": ["data"]
+    },
+    "deploy_application_to_beanstalk": {
+        "title": "Deploy Version to ElasticBeanstalk",
+        "group": "Deployment Checks",
+        "schedule": {},
+        "display": ["data"]
     }
 }

--- a/chalicelib/checks/deployment_checks.py
+++ b/chalicelib/checks/deployment_checks.py
@@ -1,0 +1,113 @@
+import boto3
+
+from ..run_result import CheckResult, ActionResult
+from ..utils import check_function, action_function
+from dcicutils.deployment_utils import EBDeployer
+from dcicutils.env_utils import (
+    FF_ENV_INDEXER, CGAP_ENV_INDEXER, is_indexer_env, is_fourfront_env, is_cgap_env
+)
+from dcicutils.beanstalk_utils import beanstalk_info, is_indexing_finished
+
+
+def try_to_describe_indexer_env(env):
+    """ Small helper that wraps beanstalk_info so we can recover from exceptions
+        XXX: Fix beanstalk_info so it will not throw IndexError if you give it bad env
+    """
+    try:
+        return beanstalk_info(env)
+    except IndexError:
+        return None  # env does not exist
+    except Exception:
+        raise  # something else happened we should (probably) raise
+
+
+@check_function(env=FF_ENV_INDEXER)  # XXX: Scope?
+def indexer_server_status(connection, **kwargs):
+    """ Checks the status of index servers (if any are up) """
+    check = CheckResult(connection, 'indexer_server_status')
+    check.action = 'terminate_indexer_server'
+    env = kwargs.get('env')
+
+    if not is_indexer_env(env):
+        raise RuntimeError('Bad EB env passed to check, should be one of: %s, %s\n'
+                           'But got: %s' % (FF_ENV_INDEXER, CGAP_ENV_INDEXER, env))
+
+    # Get info about indexer env, check indexing status
+    description = try_to_describe_indexer_env(env)
+    if description is not None:
+        indexing_finished, counts = is_indexing_finished(env)
+        if indexing_finished is True:
+            check.status = 'PASS'
+            check.summary = 'Env %s has finished indexing and is ready to be terminated' % env
+            check.action_message = 'Will terminate indexer env: %s' % env
+            check.allow_action = True  # allow us to terminate
+        else:
+            check.status = 'WARN'
+            check.allow_action = False
+            check.summary = 'Env %s has not finished indexing with remaining counts %s' % (env, counts)
+    else:
+        check.status = 'PASS'
+        check.summary = 'Did not find an online indexer with the given name: %s, so no status to check.' % env
+
+    check.full_output = env  # full_output contains env we checked
+    return check
+
+
+@action_function()
+def terminate_indexer_server(connection, **kwargs):
+    """ Terminates the index_server stored in the full_output member of the associated check above """
+    action = ActionResult(connection, 'terminate_indexer_server')
+    related_indexer_server_status = action.get_associated_check_result(kwargs)
+    env_to_terminate = related_indexer_server_status.get('full_output', None)
+
+    if env_to_terminate:
+        client = boto3.client('elasticbeanstalk')
+        success = EBDeployer.terminate_indexer_env(client, env_to_terminate)
+        if success:
+            action.status = 'DONE'
+            action.output = 'Successfully triggered termination of indexer env %s' % env_to_terminate
+        else:
+            action.status = 'FAIL'
+            action.output = 'Encountered an error while issuing terminate call, please check the AWS EB Console'
+    else:
+        action.status = 'FAIL'
+        action.output = 'Did not get an env_to_terminate from the associated check - bad action call?'
+
+    return action
+
+
+@check_function(env='fourfront-green', application_version=None)
+def provision_indexer_environment(connection, **kwargs):
+    """ Provisions an indexer environment for the given env. Note that only one indexer can be online
+        per application (one for 4DN, one for CGAP).
+    """
+    check = CheckResult(connection, 'provision_indexer_environment')
+    env = kwargs.get('env', None)
+    application_version = kwargs.get('application_version', None)
+
+    if application_version is None:
+        check.status = 'ERROR'
+        check.summary = 'Did not provide application_version to deploy indexer, which is required. ' \
+                        'Get this information from the EB Console.'
+        return check
+
+    def _deploy_indexer(e, version):
+        description = try_to_describe_indexer_env(e)
+        if description is not None:
+            check.status = 'ERROR'
+            check.summary = 'Tried to spin up indexer env for %s when one already exists for this portal' % e
+            return False
+        else:
+            return EBDeployer.deploy_indexer(e, version)
+
+    if is_cgap_env(env) or is_fourfront_env(env):
+        success = _deploy_indexer(env, application_version)
+        if success:
+            check.status = 'PASS'
+            check.summary = 'Successfully triggered indexer-server provision for environment %s' % env
+    else:
+        check.status = 'FAIL'
+        check.summary = 'Gave an unknown environment: %s' % env
+
+    return check
+

--- a/chalicelib/checks/deployment_checks.py
+++ b/chalicelib/checks/deployment_checks.py
@@ -1,6 +1,6 @@
-import os
-import shutil
+import time
 import boto3
+import shutil
 import datetime
 import tempfile
 from git import Repo
@@ -9,7 +9,7 @@ from ..run_result import CheckResult, ActionResult
 from ..utils import check_function, action_function
 from dcicutils.deployment_utils import EBDeployer
 from dcicutils.env_utils import (
-    FF_ENV_INDEXER, CGAP_ENV_INDEXER, is_indexer_env, is_fourfront_env, is_cgap_env
+    FF_ENV_INDEXER, CGAP_ENV_INDEXER, is_fourfront_env, is_cgap_env
 )
 from dcicutils.beanstalk_utils import beanstalk_info, is_indexing_finished
 
@@ -30,9 +30,9 @@ def clone_repo_to_temporary_dir(repo='https://github.com/4dn-dcic/fourfront.git'
     """ Clones the given repo (default fourfront) to a temporary directory whose
         absolute path is returned.
     """
-    tempdir = tempfile.mkdtemp()
-    Repo.clone_from(url=repo, to_path=tempdir, branch='master')
-    return os.path.join(tempdir, './fourfront')
+    tempdir = tempfile.mkdtemp(prefix=name)
+    Repo.clone_from(url=repo, to_path=tempdir)
+    return tempdir
 
 
 def cleanup_tempdir(tempdir):
@@ -40,44 +40,51 @@ def cleanup_tempdir(tempdir):
     shutil.rmtree(tempdir)
 
 
-@check_function(env=FF_ENV_INDEXER)  # XXX: Scope?
+@check_function(env='fourfront-hotseat')
 def indexer_server_status(connection, **kwargs):
     """ Checks the status of index servers (if any are up) """
     check = CheckResult(connection, 'indexer_server_status')
     check.action = 'terminate_indexer_server'
     env = kwargs.get('env')
+    indexer_env = FF_ENV_INDEXER if is_fourfront_env(env) else CGAP_ENV_INDEXER
+    description = try_to_describe_indexer_env(indexer_env)  # verify an indexer is online
+    if description is None:
+        check.status = 'ERROR'
+        check.summary = 'Did not locate corresponding indexer env: ' \
+                        'given env %s does not have indexer %s' % (env, indexer_env)
+        check.allow_action = False
+        return check
 
-    if not is_indexer_env(env):
-        raise RuntimeError('Bad EB env passed to check, should be one of: %s, %s\n'
-                           'But got: %s' % (FF_ENV_INDEXER, CGAP_ENV_INDEXER, env))
-
-    # Get info about indexer env, check indexing status
-    description = try_to_describe_indexer_env(env)
-    if description is not None:
+    try:
         indexing_finished, counts = is_indexing_finished(env)
-        if indexing_finished is True:
-            check.status = 'PASS'
-            check.summary = 'Env %s has finished indexing and is ready to be terminated' % env
-            check.action_message = 'Will terminate indexer env: %s' % env
-            check.allow_action = True  # allow us to terminate
-        else:
-            check.status = 'WARN'
-            check.allow_action = False
-            check.summary = 'Env %s has not finished indexing with remaining counts %s' % (env, counts)
-    else:
+    except Exception as e:  # XXX: This should be handled in dcicutils -Will 5/18/2020
+        check.status = 'ERROR'
+        check.summary = 'Failed to get indexing status of given env: %s' % str(e)
+        check.allow_action = False
+        return check
+
+    if indexing_finished is True:
         check.status = 'PASS'
-        check.summary = 'Did not find an online indexer with the given name: %s, so no status to check.' % env
+        check.summary = 'Env %s has finished indexing and is ready to be terminated' % env
+        check.action_message = 'Safe to terminate indexer env: %s since indexing is finished' % env
+        check.allow_action = True  # allow us to terminate
+    else:
+        check.status = 'WARN'
+        check.allow_action = True
+        check.action_message = 'Will terminate indexer env %s when indexing is not done yet!' % env
+        check.summary = 'Env %s has not finished indexing with remaining counts %s' % (env, ' '.join(counts))
 
     check.full_output = env  # full_output contains env we checked
     return check
 
 
-@action_function()
+@action_function(forced_env=None)
 def terminate_indexer_server(connection, **kwargs):
     """ Terminates the index_server stored in the full_output member of the associated check above """
     action = ActionResult(connection, 'terminate_indexer_server')
     related_indexer_server_status = action.get_associated_check_result(kwargs)
-    env_to_terminate = related_indexer_server_status.get('full_output', None)
+    forced_env = kwargs.get('forced_env', None)
+    env_to_terminate = related_indexer_server_status.get('full_output', None) if forced_env is None else forced_env
 
     if env_to_terminate:
         client = boto3.client('elasticbeanstalk')
@@ -100,7 +107,8 @@ def provision_indexer_environment(connection, **kwargs):
     """ Provisions an indexer environment for the given env. Note that only one indexer can be online
         per application (one for 4DN, one for CGAP).
 
-        NOTE: env is an EB ENV NAME ('data', 'staging' are NOT valid).
+        IMPORTANT: env is an EB ENV NAME ('data', 'staging' are NOT valid).
+        IMPORTANT: This ecosystem will break some integrated tests in dcicutils
     """
     check = CheckResult(connection, 'provision_indexer_environment')
     env = kwargs.get('env', None)
@@ -164,16 +172,12 @@ def deploy_application_to_beanstalk(connection, **kwargs):
     packaging_was_successful = EBDeployer.build_application_version(repo_location,
                                                                     application_version_name,
                                                                     branch=branch)
+    time.sleep(10)  # give EB some time to index the new template
     if packaging_was_successful:
         try:
-            deploy_succeeded = EBDeployer.deploy_new_version(env, repo_location, application_version_name)
-            if deploy_succeeded:
-                check.status = 'PASS'
-                check.summary = 'Successfully deployed version %s to env %s' % (application_version_name, env)
-            else:
-                check.status = 'WARN'
-                check.summary = 'Something went wrong when provisioning: %s' \
-                                'Please check the AWS EB Console.' % deploy_succeeded
+            EBDeployer.deploy_new_version(env, repo_location, application_version_name)
+            check.status = 'PASS'
+            check.summary = 'Successfully deployed version %s to env %s' % (application_version_name, env)
         except Exception as e:
             check.status = 'ERROR'
             check.summary = 'Error encountered while deploying: %s' % str(e)
@@ -181,5 +185,5 @@ def deploy_application_to_beanstalk(connection, **kwargs):
         check.status = 'ERROR'
         check.summary = 'Could not package repository: %s' % packaging_was_successful
 
-    cleanup_tempdir(os.path.join(repo_location, '../'))  # cleanup tempdir that houses repo
+    cleanup_tempdir(repo_location)
     return check

--- a/chalicelib/checks/es_checks.py
+++ b/chalicelib/checks/es_checks.py
@@ -1,4 +1,5 @@
 import time
+import datetime
 from ..run_result import CheckResult, ActionResult
 from ..utils import (
     check_function,
@@ -34,6 +35,7 @@ def elasticsearch_s3_count_diff(connection, **kwargs):
     check.full_output = full_output
     return check
 
+
 @action_function(timeout=270)
 def migrate_checks_to_es(connection, **kwargs):
     """
@@ -67,6 +69,7 @@ def migrate_checks_to_es(connection, **kwargs):
     action.output = action_logs
     return action
 
+
 @check_function(timeout=270, days=30, to_clean=None)
 def clean_s3_es_checks(connection, **kwargs):
     """
@@ -91,4 +94,4 @@ def clean_s3_es_checks(connection, **kwargs):
     full_output['n_deleted_es'] = n_deleted_es
     check.status = 'DONE'
     check.full_output = full_output
-    return action
+    return check

--- a/poetry.lock
+++ b/poetry.lock
@@ -37,7 +37,7 @@ description = "Screen-scraping library"
 name = "beautifulsoup4"
 optional = false
 python-versions = "*"
-version = "4.9.0"
+version = "4.9.1"
 
 [package.dependencies]
 soupsieve = [">1.2", "<2.0"]
@@ -52,10 +52,10 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = "*"
-version = "1.12.49"
+version = "1.13.11"
 
 [package.dependencies]
-botocore = ">=1.15.49,<1.16.0"
+botocore = ">=1.16.11,<1.17.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
@@ -65,7 +65,7 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = "*"
-version = "1.15.49"
+version = "1.16.11"
 
 [package.dependencies]
 docutils = ">=0.10,<0.16"
@@ -159,14 +159,16 @@ category = "main"
 description = "Utility package for interacting with the 4DN Data Portal and other 4DN resources"
 name = "dcicutils"
 optional = false
-python-versions = ">=3.4,<3.7"
-version = "0.18.0"
+python-versions = ">=3.4,<3.8"
+version = "0.27.0"
 
 [package.dependencies]
 aws-requests-auth = ">=0.4.2,<1"
 boto3 = ">=1.10.46,<2.0.0"
 botocore = ">=1.13.46,<2.0.0"
 elasticsearch = ">=5.5.3,<6.0.0"
+gitpython = ">=3.1.2,<4.0.0"
+pytz = ">=2016.4"
 requests = ">=2.21.0,<3.0.0"
 structlog = ">=19.2.0,<20.0.0"
 toml = ">=0.10.0,<1"
@@ -271,6 +273,28 @@ six = "*"
 
 [[package]]
 category = "main"
+description = "Git Object Database"
+name = "gitdb"
+optional = false
+python-versions = ">=3.4"
+version = "4.0.5"
+
+[package.dependencies]
+smmap = ">=3.0.1,<4"
+
+[[package]]
+category = "main"
+description = "Python Git Library"
+name = "gitpython"
+optional = false
+python-versions = ">=3.4"
+version = "3.1.2"
+
+[package.dependencies]
+gitdb = ">=4.0.1,<5"
+
+[[package]]
+category = "main"
 description = "Google API Client Library for Python"
 name = "google-api-python-client"
 optional = false
@@ -290,7 +314,7 @@ description = "Google Authentication Library"
 name = "google-auth"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
-version = "1.14.1"
+version = "1.14.3"
 
 [package.dependencies]
 cachetools = ">=2.0.0,<5.0"
@@ -362,8 +386,8 @@ category = "main"
 description = "JSON Matching Expressions"
 name = "jmespath"
 optional = false
-python-versions = "*"
-version = "0.9.5"
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "0.10.0"
 
 [[package]]
 category = "main"
@@ -379,7 +403,7 @@ description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
 python-versions = ">=3.5"
-version = "8.2.0"
+version = "8.3.0"
 
 [[package]]
 category = "dev"
@@ -521,6 +545,14 @@ setuptools = "*"
 
 [[package]]
 category = "main"
+description = "World timezone definitions, modern and historical"
+name = "pytz"
+optional = false
+python-versions = "*"
+version = "2020.1"
+
+[[package]]
+category = "main"
 description = "Makes it easy to respect rate limits."
 name = "ratelim"
 optional = false
@@ -580,11 +612,19 @@ version = "1.14.0"
 
 [[package]]
 category = "main"
+description = "A pure Python implementation of a sliding window memory map manager"
+name = "smmap"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "3.0.4"
+
+[[package]]
+category = "main"
 description = "A modern CSS selector implementation for Beautiful Soup."
 name = "soupsieve"
 optional = false
 python-versions = "*"
-version = "1.9.5"
+version = "1.9.6"
 
 [[package]]
 category = "main"
@@ -609,7 +649,7 @@ description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
 optional = false
 python-versions = "*"
-version = "0.10.0"
+version = "0.10.1"
 
 [[package]]
 category = "dev"
@@ -716,7 +756,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "cefd4315553319567a5208f306d4ad81a673ace933544ced42489c20bd7966e0"
+content-hash = "48c88b2cc017a0a2e4e1f0c984319480012c22ea0bc1b38e8152c170d9846f13"
 python-versions = ">=3.6,<3.7"
 
 [metadata.files]
@@ -732,17 +772,17 @@ aws-requests-auth = [
     {file = "aws-requests-auth-0.4.2.tar.gz", hash = "sha256:112c85fe938a01e28f7e1a87168615b6977b28596362b1dcbafbf4f2cc69f720"},
 ]
 beautifulsoup4 = [
-    {file = "beautifulsoup4-4.9.0-py2-none-any.whl", hash = "sha256:a4bbe77fd30670455c5296242967a123ec28c37e9702a8a81bd2f20a4baf0368"},
-    {file = "beautifulsoup4-4.9.0-py3-none-any.whl", hash = "sha256:d4e96ac9b0c3a6d3f0caae2e4124e6055c5dcafde8e2f831ff194c104f0775a0"},
-    {file = "beautifulsoup4-4.9.0.tar.gz", hash = "sha256:594ca51a10d2b3443cbac41214e12dbb2a1cd57e1a7344659849e2e20ba6a8d8"},
+    {file = "beautifulsoup4-4.9.1-py2-none-any.whl", hash = "sha256:e718f2342e2e099b640a34ab782407b7b676f47ee272d6739e60b8ea23829f2c"},
+    {file = "beautifulsoup4-4.9.1-py3-none-any.whl", hash = "sha256:a6237df3c32ccfaee4fd201c8f5f9d9df619b93121d01353a64a73ce8c6ef9a8"},
+    {file = "beautifulsoup4-4.9.1.tar.gz", hash = "sha256:73cc4d115b96f79c7d77c1c7f7a0a8d4c57860d1041df407dd1aae7f07a77fd7"},
 ]
 boto3 = [
-    {file = "boto3-1.12.49-py2.py3-none-any.whl", hash = "sha256:5a8c918c04015147f40e498994cd85c9442f6e00b4cf87ffb04f15d6a24135f4"},
-    {file = "boto3-1.12.49.tar.gz", hash = "sha256:7b82123d25100c834b71868d60e66fca37e0691edd444fb149d004ab00bea3b4"},
+    {file = "boto3-1.13.11-py2.py3-none-any.whl", hash = "sha256:fe7fa987472d8247812add0bc1c00aa2e6631589aa601b01d075d8c595c2292f"},
+    {file = "boto3-1.13.11.tar.gz", hash = "sha256:a7c5c7251b76336e697ccf368f125720e1947d58b218c228b61b5b654187fe4e"},
 ]
 botocore = [
-    {file = "botocore-1.15.49-py2.py3-none-any.whl", hash = "sha256:b805691b4dedcb2a252f52347479ff351429624a873f001b6a1c81aca03dccee"},
-    {file = "botocore-1.15.49.tar.gz", hash = "sha256:a474131ba7a7d700b91696a27e8cdcf1b473084addf92f90b269ebd8f5c3d3e0"},
+    {file = "botocore-1.16.11-py2.py3-none-any.whl", hash = "sha256:e7fd44235f3e197558ea8f85f078a6bd05805eea90ed2a00b5cb2646ac800157"},
+    {file = "botocore-1.16.11.tar.gz", hash = "sha256:b82083f1ba65624017d53fa2d2a44aa801ea3da0948fba56ccf4d29a88ef0b71"},
 ]
 cachetools = [
     {file = "cachetools-4.1.0-py3-none-any.whl", hash = "sha256:de5d88f87781602201cde465d3afe837546663b168e8b39df67411b0bf10cefc"},
@@ -802,8 +842,8 @@ coverage = [
     {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
 ]
 dcicutils = [
-    {file = "dcicutils-0.18.0-py3-none-any.whl", hash = "sha256:552aa3ee44c5007cab8ee26553584e952424d3d587857a99b44e757ba00cc97c"},
-    {file = "dcicutils-0.18.0.tar.gz", hash = "sha256:c1b2cb941f7adaaeb432d12f4eb2d2f6ac327991ea2348d37dab4f8a40c56925"},
+    {file = "dcicutils-0.27.0-py3-none-any.whl", hash = "sha256:6a91109ab69d724fde208f675b50fa5ba20656898be2748de4f0be3938a11539"},
+    {file = "dcicutils-0.27.0.tar.gz", hash = "sha256:219a9695b8512bf2adf97ab20f9e79570fc193ef7b504884564952380135268f"},
 ]
 decorator = [
     {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
@@ -841,13 +881,21 @@ geocoder = [
     {file = "geocoder-1.38.1-py2.py3-none-any.whl", hash = "sha256:a733e1dfbce3f4e1a526cac03aadcedb8ed1239cf55bd7f3a23c60075121a834"},
     {file = "geocoder-1.38.1.tar.gz", hash = "sha256:c9925374c961577d0aee403b09e6f8ea1971d913f011f00ca70c76beaf7a77e7"},
 ]
+gitdb = [
+    {file = "gitdb-4.0.5-py3-none-any.whl", hash = "sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac"},
+    {file = "gitdb-4.0.5.tar.gz", hash = "sha256:c9e1f2d0db7ddb9a704c2a0217be31214e91a4fe1dea1efad19ae42ba0c285c9"},
+]
+gitpython = [
+    {file = "GitPython-3.1.2-py3-none-any.whl", hash = "sha256:da3b2cf819974789da34f95ac218ef99f515a928685db141327c09b73dd69c09"},
+    {file = "GitPython-3.1.2.tar.gz", hash = "sha256:864a47472548f3ba716ca202e034c1900f197c0fb3a08f641c20c3cafd15ed94"},
+]
 google-api-python-client = [
     {file = "google-api-python-client-1.7.4.tar.gz", hash = "sha256:5d5cb02c6f3112c68eed51b74891a49c0e35263380672d662f8bfe85b8114d7c"},
     {file = "google_api_python_client-1.7.4-py3-none-any.whl", hash = "sha256:7cc47cf80b25ecd7f3d917ea247bb6c62587514e40604ae29c47c0e4ebd1174b"},
 ]
 google-auth = [
-    {file = "google-auth-1.14.1.tar.gz", hash = "sha256:e63b2210e03c4ed829063b72c4af0c4b867c2788efb3210b6b9439b488bd3afd"},
-    {file = "google_auth-1.14.1-py2.py3-none-any.whl", hash = "sha256:0c41a453b9a8e77975bfa436b8daedac00aed1c545d84410daff8272fff40fbb"},
+    {file = "google-auth-1.14.3.tar.gz", hash = "sha256:82d32f6601f35309c95d5917bcdf72f3ec193c7f46c79e433b8d76ccbe68e21d"},
+    {file = "google_auth-1.14.3-py2.py3-none-any.whl", hash = "sha256:4942ab1ff530e740866571c0416fb5a7dc9ec53233a8f8dff63e8cd7371003d1"},
 ]
 google-auth-httplib2 = [
     {file = "google-auth-httplib2-0.0.3.tar.gz", hash = "sha256:098fade613c25b4527b2c08fa42d11f3c2037dda8995d86de0745228e965d445"},
@@ -870,15 +918,15 @@ jinja2 = [
     {file = "Jinja2-2.10.1.tar.gz", hash = "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013"},
 ]
 jmespath = [
-    {file = "jmespath-0.9.5-py2.py3-none-any.whl", hash = "sha256:695cb76fa78a10663425d5b73ddc5714eb711157e52704d69be03b1a02ba4fec"},
-    {file = "jmespath-0.9.5.tar.gz", hash = "sha256:cca55c8d153173e21baa59983015ad0daf603f9cb799904ff057bfb8ff8dc2d9"},
+    {file = "jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"},
+    {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
 ]
 markupsafe = [
     {file = "MarkupSafe-1.0.tar.gz", hash = "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.2.0.tar.gz", hash = "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"},
-    {file = "more_itertools-8.2.0-py3-none-any.whl", hash = "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c"},
+    {file = "more-itertools-8.3.0.tar.gz", hash = "sha256:558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be"},
+    {file = "more_itertools-8.3.0-py3-none-any.whl", hash = "sha256:7818f596b1e87be009031c7653d01acc46ed422e6656b394b0f765ce66ed4982"},
 ]
 packaging = [
     {file = "packaging-20.3-py2.py3-none-any.whl", hash = "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"},
@@ -945,6 +993,10 @@ python-dateutil = [
 python-levenshtein = [
     {file = "python-Levenshtein-0.12.0.tar.gz", hash = "sha256:033a11de5e3d19ea25c9302d11224e1a1898fe5abd23c61c7c360c25195e3eb1"},
 ]
+pytz = [
+    {file = "pytz-2020.1-py2.py3-none-any.whl", hash = "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed"},
+    {file = "pytz-2020.1.tar.gz", hash = "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"},
+]
 ratelim = [
     {file = "ratelim-0.1.6-py2.py3-none-any.whl", hash = "sha256:e1a7dd39e6b552b7cc7f52169cd66cdb826a1a30198e355d7016012987c9ad08"},
     {file = "ratelim-0.1.6.tar.gz", hash = "sha256:826d32177e11f9a12831901c9fda6679fd5bbea3605910820167088f5acbb11d"},
@@ -965,18 +1017,21 @@ six = [
     {file = "six-1.14.0-py2.py3-none-any.whl", hash = "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"},
     {file = "six-1.14.0.tar.gz", hash = "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a"},
 ]
+smmap = [
+    {file = "smmap-3.0.4-py2.py3-none-any.whl", hash = "sha256:54c44c197c819d5ef1991799a7e30b662d1e520f2ac75c9efbeb54a742214cf4"},
+    {file = "smmap-3.0.4.tar.gz", hash = "sha256:9c98bbd1f9786d22f14b3d4126894d56befb835ec90cef151af566c7e19b5d24"},
+]
 soupsieve = [
-    {file = "soupsieve-1.9.5-py2.py3-none-any.whl", hash = "sha256:bdb0d917b03a1369ce964056fc195cfdff8819c40de04695a80bc813c3cfa1f5"},
-    {file = "soupsieve-1.9.5.tar.gz", hash = "sha256:e2c1c5dee4a1c36bcb790e0fabd5492d874b8ebd4617622c4f6a731701060dda"},
+    {file = "soupsieve-1.9.6-py2.py3-none-any.whl", hash = "sha256:feb1e937fa26a69e08436aad4a9037cd7e1d4c7212909502ba30701247ff8abd"},
+    {file = "soupsieve-1.9.6.tar.gz", hash = "sha256:7985bacc98c34923a439967c1a602dc4f1e15f923b6fcf02344184f86cc7efaa"},
 ]
 structlog = [
     {file = "structlog-19.2.0-py2.py3-none-any.whl", hash = "sha256:6640e6690fc31d5949bc614c1a630464d3aaa625284aeb7c6e486c3010d73e12"},
     {file = "structlog-19.2.0.tar.gz", hash = "sha256:4287058cf4ce1a59bc5dea290d6386d37f29a37529c9a51cdf7387e51710152b"},
 ]
 toml = [
-    {file = "toml-0.10.0-py2.7.egg", hash = "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"},
-    {file = "toml-0.10.0-py2.py3-none-any.whl", hash = "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"},
-    {file = "toml-0.10.0.tar.gz", hash = "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c"},
+    {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
+    {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
 ]
 typing = [
     {file = "typing-3.6.4-py2-none-any.whl", hash = "sha256:b2c689d54e1144bbcfd191b0832980a21c2dbcf7b5ff7a66248a60c90e951eb8"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -756,7 +756,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "48c88b2cc017a0a2e4e1f0c984319480012c22ea0bc1b38e8152c170d9846f13"
+content-hash = "1f5567eec92931926a82fa3ccf384080da13ed0cd63354b13636d393c78aa51b"
 python-versions = ">=3.6,<3.7"
 
 [metadata.files]

--- a/poetry.lock
+++ b/poetry.lock
@@ -52,10 +52,10 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = "*"
-version = "1.13.11"
+version = "1.13.12"
 
 [package.dependencies]
-botocore = ">=1.16.11,<1.17.0"
+botocore = ">=1.16.12,<1.17.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
@@ -65,7 +65,7 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = "*"
-version = "1.16.11"
+version = "1.16.12"
 
 [package.dependencies]
 docutils = ">=0.10,<0.16"
@@ -160,7 +160,7 @@ description = "Utility package for interacting with the 4DN Data Portal and othe
 name = "dcicutils"
 optional = false
 python-versions = ">=3.4,<3.8"
-version = "0.27.0"
+version = "0.28.1"
 
 [package.dependencies]
 aws-requests-auth = ">=0.4.2,<1"
@@ -314,7 +314,7 @@ description = "Google Authentication Library"
 name = "google-auth"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
-version = "1.14.3"
+version = "1.15.0"
 
 [package.dependencies]
 cachetools = ">=2.0.0,<5.0"
@@ -411,7 +411,7 @@ description = "Core utilities for Python packages"
 name = "packaging"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.3"
+version = "20.4"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
@@ -756,7 +756,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "1f5567eec92931926a82fa3ccf384080da13ed0cd63354b13636d393c78aa51b"
+content-hash = "e3ee18fb805fdd39d82140dd3b1dce485879baa6592e90c920ce34730b3fef9b"
 python-versions = ">=3.6,<3.7"
 
 [metadata.files]
@@ -777,12 +777,12 @@ beautifulsoup4 = [
     {file = "beautifulsoup4-4.9.1.tar.gz", hash = "sha256:73cc4d115b96f79c7d77c1c7f7a0a8d4c57860d1041df407dd1aae7f07a77fd7"},
 ]
 boto3 = [
-    {file = "boto3-1.13.11-py2.py3-none-any.whl", hash = "sha256:fe7fa987472d8247812add0bc1c00aa2e6631589aa601b01d075d8c595c2292f"},
-    {file = "boto3-1.13.11.tar.gz", hash = "sha256:a7c5c7251b76336e697ccf368f125720e1947d58b218c228b61b5b654187fe4e"},
+    {file = "boto3-1.13.12-py2.py3-none-any.whl", hash = "sha256:bf1346365829525dfd8dbbafb5dbfd7383ad0872370301643d65c6190f7f5813"},
+    {file = "boto3-1.13.12.tar.gz", hash = "sha256:c46f31f085de660b95162c66057bae9ebb1658a245c9210162cee9671b0ff678"},
 ]
 botocore = [
-    {file = "botocore-1.16.11-py2.py3-none-any.whl", hash = "sha256:e7fd44235f3e197558ea8f85f078a6bd05805eea90ed2a00b5cb2646ac800157"},
-    {file = "botocore-1.16.11.tar.gz", hash = "sha256:b82083f1ba65624017d53fa2d2a44aa801ea3da0948fba56ccf4d29a88ef0b71"},
+    {file = "botocore-1.16.12-py2.py3-none-any.whl", hash = "sha256:446c9279105f596765ece99b61656f76c5d5003556cd8301dd506d4f70e18940"},
+    {file = "botocore-1.16.12.tar.gz", hash = "sha256:b75a5dc97f9ac795139ea2c651c07a8522e31dc280db17243e2b20e5c210547b"},
 ]
 cachetools = [
     {file = "cachetools-4.1.0-py3-none-any.whl", hash = "sha256:de5d88f87781602201cde465d3afe837546663b168e8b39df67411b0bf10cefc"},
@@ -842,8 +842,8 @@ coverage = [
     {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
 ]
 dcicutils = [
-    {file = "dcicutils-0.27.0-py3-none-any.whl", hash = "sha256:6a91109ab69d724fde208f675b50fa5ba20656898be2748de4f0be3938a11539"},
-    {file = "dcicutils-0.27.0.tar.gz", hash = "sha256:219a9695b8512bf2adf97ab20f9e79570fc193ef7b504884564952380135268f"},
+    {file = "dcicutils-0.28.1-py3-none-any.whl", hash = "sha256:b3c3433ebc417e68b5cdb4f456d10e1f21d015a325acceb8b60c182ec2bbeb37"},
+    {file = "dcicutils-0.28.1.tar.gz", hash = "sha256:cb4de6831e327accc383245a5e5db62c8a4f2f10e34ed12ffb2c5f0507bdbb7b"},
 ]
 decorator = [
     {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
@@ -894,8 +894,8 @@ google-api-python-client = [
     {file = "google_api_python_client-1.7.4-py3-none-any.whl", hash = "sha256:7cc47cf80b25ecd7f3d917ea247bb6c62587514e40604ae29c47c0e4ebd1174b"},
 ]
 google-auth = [
-    {file = "google-auth-1.14.3.tar.gz", hash = "sha256:82d32f6601f35309c95d5917bcdf72f3ec193c7f46c79e433b8d76ccbe68e21d"},
-    {file = "google_auth-1.14.3-py2.py3-none-any.whl", hash = "sha256:4942ab1ff530e740866571c0416fb5a7dc9ec53233a8f8dff63e8cd7371003d1"},
+    {file = "google-auth-1.15.0.tar.gz", hash = "sha256:fbf25fee328c0828ef293459d9c649ef84ee44c0b932bb999d19df0ead1b40cf"},
+    {file = "google_auth-1.15.0-py2.py3-none-any.whl", hash = "sha256:73b141d122942afe12e8bfdcb6900d5df35c27d39700f078363ba0b1298ad33b"},
 ]
 google-auth-httplib2 = [
     {file = "google-auth-httplib2-0.0.3.tar.gz", hash = "sha256:098fade613c25b4527b2c08fa42d11f3c2037dda8995d86de0745228e965d445"},
@@ -929,8 +929,8 @@ more-itertools = [
     {file = "more_itertools-8.3.0-py3-none-any.whl", hash = "sha256:7818f596b1e87be009031c7653d01acc46ed422e6656b394b0f765ce66ed4982"},
 ]
 packaging = [
-    {file = "packaging-20.3-py2.py3-none-any.whl", hash = "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"},
-    {file = "packaging-20.3.tar.gz", hash = "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3"},
+    {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
+    {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ fuzzywuzzy = "0.17.0"
 elasticsearch = "5.5.3"
 elasticsearch-dsl = "5.3.0"
 python-Levenshtein = "0.12.0"
+gitpython = "^3.1.2"
 
 [tool.poetry.dev-dependencies]
 chalice = "1.11.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "0.11.0"
+version = "0.11.1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN Team <william_ronchetti@hms.harvard.edu>"]
 license = "MIT"
@@ -10,7 +10,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.6,<3.7"
-dcicutils = "^0.27.0"
+dcicutils = "^0.28.1"
 click = "6.7"
 PyJWT = "1.5.3"
 Jinja2 = "2.10.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "0.10.6"
+version = "0.11.0"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN Team <william_ronchetti@hms.harvard.edu>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.6,<3.7"
-dcicutils = "^0.18.0"
+dcicutils = "^0.27.0"
 click = "6.7"
 PyJWT = "1.5.3"
 Jinja2 = "2.10.1"


### PR DESCRIPTION
Adds the following checks/actions:
- `indexer_server_status`: will report the status of currently running indexer servers given a base environment. For example, if you spun up an indexer server for `fourfront-hotseat`, you would pass `fourfront-hotseat` as the `env` kwarg.
- `terminate_indexer_server`: action associated with `indexer_server_status`. Run the above check to get access to this action, which when run will terminate the associated indexer server. You can also force an indexer server environment with the `forced_env` kwarg.
- `provision_indexer_environment`: check that when queued will spin up an indexer server for the given environment and application_version, both required. To see the application version, navigate to the EB console and select the relevant environment - it is at the top in-between health and platform.
- `deploy_application_to_beanstalk`: check that will deploy the application to Elastic Beanstalk given an environment, branch, application_version (to use, optional) and repository (if you want a CGAP deployment, optional for FF). This check will allow us to very easily schedule deployments through Foursight for all environments as desired.