### PR TITLE
C4-171 Fix nested checks

### DIFF
--- a/chalicelib/checks/deployment_checks.py
+++ b/chalicelib/checks/deployment_checks.py
@@ -150,13 +150,13 @@ def provision_indexer_environment(connection, **kwargs):
     return check
 
 
-@check_function(env='fourfront-mastertest',
-                branch='master',
-                application_version_name=None, repo=None)
-def deploy_application_to_beanstalk(connection, **kwargs):
-    """ Deploys application to beanstalk under the given application_version name + a branch
+def _deploy_application_to_beanstalk(connection, **kwargs):
+    """ Creates and returns a CheckResult for 'deploy_application_to_beanstalk'.
 
-        NOTE: CGAP requires kwargs!
+        NOTE: this does NOT have the @check_function decorator because I'd like
+        to "call this check" in other checks. The decorator will effectively cast
+        the resulting check to a dictionary, breaking nested checks. This could be
+        fixed by refactoring "store_formatted_result". - Will 05/28/2020
     """
     check = CheckResult(connection, 'deploy_application_to_beanstalk')
     env = kwargs.get('env', 'fourfront-mastertest')  # by default
@@ -196,11 +196,33 @@ def deploy_application_to_beanstalk(connection, **kwargs):
     return check
 
 
+@check_function(env='fourfront-mastertest',
+                branch='master',
+                application_version_name=None, repo=None)
+def deploy_application_to_beanstalk(connection, **kwargs):
+    """ Deploys application to beanstalk under the given application_version name + a branch
+        Uses the above helper method, returning the (decorated, thus stored) check directly.
+
+        NOTE: CGAP requires kwargs!
+    """
+    return _deploy_application_to_beanstalk(connection, **kwargs)
+
+
 @check_function()
 def deploy_ff_staging(connection, **kwargs):
     """ Deploys Fourfront master to whoever staging is.
         Runs as part of the 'deployment_checks' schedule on data ONLY.
     """
-    return deploy_application_to_beanstalk(connection,
-                                           env=compute_ff_stg_env(),
-                                           branch='master')
+    this_check = CheckResult(connection, 'deploy_ff_staging')
+    env_to_deploy = compute_ff_stg_env()
+    helper_check = _deploy_application_to_beanstalk(connection,
+                                                    env='fourfront-mastertest',
+                                                    branch='master')
+    if helper_check.status == 'PASS':
+        this_check.status = 'PASS'
+        this_check.summary = 'Successfully deployed Fourfront master to %s' % env_to_deploy
+    else:
+        this_check.status = 'ERROR'
+        this_check.summary = 'Error occurred during deployment, see full_output'
+        this_check.full_output = helper_check.summary  # should have error message
+    return this_check

--- a/chalicelib/checks/deployment_checks.py
+++ b/chalicelib/checks/deployment_checks.py
@@ -216,7 +216,7 @@ def deploy_ff_staging(connection, **kwargs):
     this_check = CheckResult(connection, 'deploy_ff_staging')
     env_to_deploy = compute_ff_stg_env()
     helper_check = _deploy_application_to_beanstalk(connection,
-                                                    env='fourfront-mastertest',
+                                                    env=env_to_deploy,
                                                     branch='master')
     if helper_check.status == 'PASS':
         this_check.status = 'PASS'


### PR DESCRIPTION
- Some deployment checks tried to take advantage of nested checks, which do not function correctly out of the box. The check function itself runs but crashes in the decorator code.
- I have implemented a workaround to effectively allow nested checks in a specific scenario, but this should be revisited in the future. See associated comment.