### PR TITLE
Higlass registration with local beddb files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "0.11.9"
+version = "0.11.10"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
During file registration on the Higlass server, `beddb` files will now be copied from S3 to the local file system of the Higlass server. A simple flask server component on the server is triggered via foursight that will copy the corresponding files. This was necessary, due to the low performance of mounted `beddb` files.