### PR TITLE
C4-262 Fix main page inefficiency

### DIFF
--- a/chalicelib/app_utils.py
+++ b/chalicelib/app_utils.py
@@ -236,8 +236,32 @@ def query_params_to_literals(params):
     return params
 
 
+def get_size(obj, seen=None):
+    """ Recursively finds size of objects
+        Taken directly from: https://goshippo.com/blog/measure-real-size-any-python-object/
+    """
+    size = sys.getsizeof(obj)
+    if seen is None:
+        seen = set()
+    obj_id = id(obj)
+    if obj_id in seen:
+        return 0
+    # Important mark as seen *before* entering recursion to gracefully handle
+    # self-referential objects
+    seen.add(obj_id)
+    if isinstance(obj, dict):
+        size += sum([get_size(v, seen) for v in obj.values()])
+        size += sum([get_size(k, seen) for k in obj.keys()])
+    elif hasattr(obj, '__dict__'):
+        size += get_size(obj.__dict__, seen)
+    elif hasattr(obj, '__iter__') and not isinstance(obj, (str, bytes, bytearray)):
+        size += sum([get_size(i, seen) for i in obj])
+    return size
+
+
 def trim_output(output, max_size=100000):
-    """ Uses sys.getsizeof instead of encoding as JSON to determine if the output size is too large.
+    """ Uses the helper above with sys.getsizeof to determine the output size and remove it if it is too large.
+        Instead of encoding as JSON as that is very slow.
 
     Old docstring below:
 
@@ -254,7 +278,7 @@ def trim_output(output, max_size=100000):
     #     return ''.join([formatted[:max_size], '\n\n... Output truncated ...'])
     # else:
     #     return formatted
-    size = sys.getsizeof(output)
+    size = get_size(output)
     if size > max_size:
         return 'Output too large to provide on main page - see check result directly'
     return output

--- a/chalicelib/app_utils.py
+++ b/chalicelib/app_utils.py
@@ -521,11 +521,6 @@ def process_view_result(connection, res, is_admin):
                 # not yet run, display an icon status to signify this
                 res['assc_action_status'] = 'ready'
 
-            # If we got an action, set its name to 'latest action'
-            # so we can grab it's history via same method as this check
-            latest_action = action.get_latest_result()
-            if latest_action:
-                res['latest_action'] = latest_action.get('name')
         else:
             del res['action']
     return res

--- a/chalicelib/app_utils.py
+++ b/chalicelib/app_utils.py
@@ -259,6 +259,9 @@ def get_size(obj, seen=None):
     return size
 
 
+TRIM_ERR_OUTPUT = 'Output too large to provide on main page - see check result directly'
+
+
 def trim_output(output, max_size=100000):
     """ Uses the helper above with sys.getsizeof to determine the output size and remove it if it is too large.
         Instead of encoding as JSON as that is very slow.
@@ -280,7 +283,7 @@ def trim_output(output, max_size=100000):
     #     return formatted
     size = get_size(output)
     if size > max_size:
-        return 'Output too large to provide on main page - see check result directly'
+        return TRIM_ERR_OUTPUT
     return output
 
 

--- a/chalicelib/app_utils.py
+++ b/chalicelib/app_utils.py
@@ -257,6 +257,7 @@ def trim_output(output, max_size=100000):
     size = sys.getsizeof(output)
     if size > max_size:
         return 'Output too large to provide on main page - see check result directly'
+    return output
 
 
 ##### ROUTE RUNNING FUNCTIONS #####

--- a/chalicelib/app_utils.py
+++ b/chalicelib/app_utils.py
@@ -521,6 +521,10 @@ def process_view_result(connection, res, is_admin):
                 # not yet run, display an icon status to signify this
                 res['assc_action_status'] = 'ready'
 
+            # This used to try to get the latest result and only populate 'latest_action' if one exists.
+            # Doing so makes the main page take 2-3x as long to load, so we won't be doing that anymore.
+            res['action_history'] = res.get('action')  # = action name
+
         else:
             del res['action']
     return res

--- a/chalicelib/templates/base.html
+++ b/chalicelib/templates/base.html
@@ -82,8 +82,8 @@
                     <a class="commonstyle own-line" target="_blank" href={{context + 'history/' + environment + '/' + check['name']}}>
                         Result History
                     </a>
-                    {% if check.get('latest_action') %}
-                      <a class="commonstyle own-line" target="_blank" href={{context + 'history/' + environment + '/' + check['latest_action']}}>
+                    {% if check.get('action_history') %}
+                      <a class="commonstyle own-line" target="_blank" href={{context + 'history/' + environment + '/' + check['action_history']}}>
                         Action History
                       </a>
                     {% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "0.12.1"
+version = "0.12.2"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/tests/test_app_utils.py
+++ b/tests/test_app_utils.py
@@ -171,11 +171,10 @@ class TestAppUtils():
     def test_trim_output(self):
         short_output = {'some_field': 'some_value'}
         trimmed_short = app_utils.trim_output(short_output)
-        assert (trimmed_short == json.dumps(short_output, indent=4))
+        assert (trimmed_short == {'some_field': 'some_value'})
         long_output = {'some_field': 'some_value ' * 100000}
         trimmed_long = app_utils.trim_output(long_output)
-        assert (trimmed_long != json.dumps(long_output, indent=4))
-        assert (trimmed_long.endswith('\n\n... Output truncated ...'))
+        assert trimmed_long == 'Output too large to provide on main page - see check result directly'
 
     def test_query_params_to_literals(self):
         test_params = {

--- a/tests/test_app_utils.py
+++ b/tests/test_app_utils.py
@@ -174,7 +174,7 @@ class TestAppUtils():
         assert (trimmed_short == {'some_field': 'some_value'})
         long_output = {'some_field': 'some_value ' * 100000}
         trimmed_long = app_utils.trim_output(long_output)
-        assert trimmed_long == 'Output too large to provide on main page - see check result directly'
+        assert trimmed_long == app_utils.TRIM_ERR_OUTPUT
 
     def test_query_params_to_literals(self):
         test_params = {


### PR DESCRIPTION
- When getting the main page, for all checks that have an action we (synchronously) attempt to get the latest result for that action and populate `latest_action` with the action name.
- This causes the main page to take several seconds longer to load
- Instead, show the action history link for all checks by default (without the additional get per check). This does mean the link will show up for checks that do not have any action history, but I think that is acceptable given the cost.
- Reduces page load time from ~18 seconds to ~12 seconds on local (approximately ~7 to ~5 seconds on production)
- Optimizes out some unneeded API calls
- Optimizes out lots of calls to `json.dumps` while trimming output, which is very slow, instead favoring using a utility based off of `sys.getsizeof` which is faster.