### PR TITLE
New check for "grouped with" file relation consistency

### DIFF
--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -1653,5 +1653,17 @@
                 }
             }
         }
+    },
+    "grouped_with_file_relation_consistency": {
+        "title": "File relation 'grouped with'",
+        "group": "Metadata checks",
+        "schedule": {
+            "morning_checks": {
+                "data": {
+                    "kwargs": {"primary": true},
+                    "dependencies": []
+                }
+            }
+        }
     }
 }

--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -2063,7 +2063,9 @@ def grouped_with_file_relation_consistency(connection, **kwargs):
     groups = []
     newgroups = [set(rel).union({file}) for file, rel in file2grp.items()]
 
-    # merge intersecting groups until there is any
+    # Check if any pair of groups in the list has a common file (intersection).
+    # In that case, they are parts of the same group: merge them.
+    # Repeat until all groups are disjoint (not intersecting).
     while len(groups) != len(newgroups):
         groups, newgroups = newgroups, []
         for a_group in groups:
@@ -2095,7 +2097,7 @@ def grouped_with_file_relation_consistency(connection, **kwargs):
         check.description = "{} files are missing 'grouped with' relationships".format(len(missing))
         check.allow_action = True
         check.action_message = ("DO NOT RUN if relations need to be removed! "
-            "This action will attempt to patch {} items with the missing 'grouped with' relations".format(len(to_patch)))
+            "This action will attempt to patch {} items by adding the missing 'grouped with' relations".format(len(to_patch)))
     else:
         check.status = 'PASS'
         check.summary = check.description = "All 'grouped with' file relationships are consistent"

--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -2094,7 +2094,8 @@ def grouped_with_file_relation_consistency(connection, **kwargs):
         check.summary = 'File relationships are missing'
         check.description = "{} files are missing 'grouped with' relationships".format(len(missing))
         check.allow_action = True
-        check.action_message = "Will attempt to patch {} items with the missing 'grouped with' relations".format(len(to_patch))
+        check.action_message = ("DO NOT RUN if relations need to be removed! "
+            "This action will attempt to patch {} items with the missing 'grouped with' relations".format(len(to_patch)))
     else:
         check.status = 'PASS'
         check.summary = check.description = "All 'grouped with' file relationships are consistent"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "0.12.1"
+version = "0.12.2"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Check if "grouped with" file relationships are reciprocal and complete.
While other types of file relationships are automatically updated on the related file, "grouped with" ones need to be explicitly (manually) patched on the related file. This check ensures that there are no related files that lack the reciprocal relationship, or that lack some of the group relationships (for groups larger than 2 files).
