### PR TITLE
Refactor wipe_build_indices

### DIFF
--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -1686,5 +1686,31 @@
                 }
             }
         }
+    },
+    "wipe_cgap_build_indices": {
+        "title": "Wipe CGAP build indices",
+        "group": "System Checks",
+        "schedule": {
+             "morning_checks": {
+                "cgap": {
+                    "kwargs": {
+                        "primary": true
+                    }
+                }
+            }
+        }
+    },
+     "wipe_ff_build_indices": {
+        "title": "Wipe FF build indices",
+        "group": "System Checks",
+        "schedule": {
+             "morning_checks": {
+                "data": {
+                    "kwargs": {
+                        "primary": true
+                    }
+                }
+            }
+        }
     }
 }

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -1522,17 +1522,6 @@
             }
         }
     },
-    "wipe_build_indices" : {
-        "title": "Wipe Build Indicies",
-        "group": "System checks",
-        "schedule": {
-            "morning_checks": {
-                "data": {
-                    "kwargs": {"primary": true}
-                }
-            }
-        }
-    },
     "check_for_strandedness_consistency": {
         "title": "RNA-seq experiments without strandedness verification",
         "group": "Metadata checks",

--- a/chalicelib/checks/system_checks.py
+++ b/chalicelib/checks/system_checks.py
@@ -1,10 +1,9 @@
 from __future__ import print_function, unicode_literals
 from ..utils import (
     check_function,
-    action_function,
     basestring
 )
-from ..run_result import CheckResult, ActionResult
+from ..run_result import CheckResult
 from dcicutils import (
     ff_utils,
     es_utils,
@@ -13,27 +12,10 @@ from dcicutils import (
 )
 
 import requests
-import sys
 import json
 import datetime
 import boto3
 import time
-
-
-@check_function()
-def wipe_build_indices(connection, **kwargs):
-    """ Wipes all indices on the FF-Build ES env """
-    check = CheckResult(connection, 'wipe_build_indices')
-    check.status = 'PASS'
-    check.summary = check.description = 'Wiped all test indices'
-    BUILD_ES = 'search-fourfront-builds-uhevxdzfcv7mkm5pj5svcri3aq.us-east-1.es.amazonaws.com:80'
-    client = es_utils.create_es_client(BUILD_ES, True)
-    full_output = client.indices.delete(index='*')
-    if full_output['acknowledged'] != True:
-        check.status = 'FAIL'
-        check.summary = check.description = 'Failed to wipe all test indices, see full output'
-    check.full_output = full_output
-    return check
 
 
 @check_function()

--- a/chalicelib/checks/system_checks.py
+++ b/chalicelib/checks/system_checks.py
@@ -3,7 +3,7 @@ from ..utils import (
     check_function,
     basestring
 )
-from ..run_result import CheckResult
+from ..run_result import CheckResult,
 from dcicutils import (
     ff_utils,
     es_utils,
@@ -16,6 +16,45 @@ import json
 import datetime
 import boto3
 import time
+
+
+# XXX: put into utils?
+CGAP_TEST_CLUSTER = 'search-cgap-testing-ud3ggpjj7x6vclx62nmzymyzfi.us-east-1.es.amazonaws.com:80'
+FF_TEST_CLUSTER = 'search-fourfront-testing-hjozudm7pq5wwlssx2pjlsyz7y.us-east-1.es.amazonaws.com:80'
+TEST_ES_CLUSTERS = [
+    CGAP_TEST_CLUSTER,
+    FF_TEST_CLUSTER
+]
+
+
+def wipe_build_indices(connection, es_url):
+    """ Wipes all number-prefixed indices on the given es_url. Be careful not to run while
+        builds are running as this will cause them to fail.
+    """
+    check = CheckResult(connection, 'wipe_build_indices')
+    check.status = 'PASS'
+    check.summary = check.description = 'Wiped all test indices on url: %s' % es_url
+    client = es_utils.create_es_client(es_url, True)
+    full_output = []
+    for i in range(1, 10):  # delete all number prefixed indices 0-9
+        full_output.append(client.indices.delete(index=str(i) + '*'))
+    if any(output['acknowledged'] != True for output in full_output):
+        check.status = 'FAIL'
+        check.summary = check.description = 'Failed to wipe all test indices, see full output'
+    check.full_output = full_output
+    return check
+
+
+@check_function()
+def wipe_cgap_build_indices(connection):
+    """ Wipes build indices for CGAP (on cgap-testing) """
+    return wipe_build_indices(connection, CGAP_TEST_CLUSTER)
+
+
+@check_function()
+def wipe_ff_build_indices(connection):
+    """ Wipes build (number prefixed) indices (on fourfront-testing) """
+    return wipe_build_indices(connection, FF_TEST_CLUSTER)
 
 
 @check_function()

--- a/chalicelib/checks/system_checks.py
+++ b/chalicelib/checks/system_checks.py
@@ -3,7 +3,7 @@ from ..utils import (
     check_function,
     basestring
 )
-from ..run_result import CheckResult,
+from ..run_result import CheckResult
 from dcicutils import (
     ff_utils,
     es_utils,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "0.12.4"
+version = "0.12.5"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
- Refactor `wipe_build_indices` to be FF/CGAP specific and run on the production schedule (morning checks) of each
- Instead of deleting `*`, we delete indices that have numeric prefixes. This convention has been communicated to others, but I don't think anything except Travis is using numerical prefixes.