### PR TITLE
fastq pipelines only on fastq format

### DIFF
--- a/chalicelib/checks/audit_checks.py
+++ b/chalicelib/checks/audit_checks.py
@@ -197,8 +197,8 @@ def paired_end_info_consistent(connection, **kwargs):
     '''
     check = CheckResult(connection, 'paired_end_info_consistent')
 
-    search1 = 'search/?type=FileFastq&related_files.relationship_type=paired+with&paired_end=No+value'
-    search2 = 'search/?type=FileFastq&related_files.relationship_type!=paired+with&paired_end%21=No+value'
+    search1 = 'search/?type=FileFastq&file_format.file_format=fastq&related_files.relationship_type=paired+with&paired_end=No+value'
+    search2 = 'search/?type=FileFastq&file_format.file_format=fastq&related_files.relationship_type!=paired+with&paired_end%21=No+value'
 
     results1 = ff_utils.search_metadata(search1 + '&frame=object', key=connection.ff_keys)
     results2 = ff_utils.search_metadata(search2 + '&frame=object', key=connection.ff_keys)

--- a/chalicelib/checks/helpers/wfr_utils.py
+++ b/chalicelib/checks/helpers/wfr_utils.py
@@ -637,6 +637,8 @@ def find_fastq_info(my_rep_set, fastq_files, type=None):
       file dict  { exp1 : [ [file1, file2], [file3, file4]]} # paired
     - refs keys  {pairing, organism, enzyme, bwa_ref, chrsize_ref, enz_ref, f_size, lab}
     """
+    # remove non fastq.gz files from the file list
+    fastq_files = [i for i in fastq_files if i['file_format']['file_format'] == 'fastq']
     file_dict = {}
     refs = {}
     # check pairing for the first file, and assume all same

--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -1894,7 +1894,7 @@ def fastq_first_line_status(connection, **kwargs):
         return check
 
     query = ('/search/?status=uploaded&status=pre-release&status=released+to+project&status=released'
-             '&type=FileFastq&file_first_line=No value&status=restricted')
+             '&type=FileFastq&file_format.file_format=fastq&file_first_line=No value&status=restricted')
 
     # The search
     print('About to query ES for files')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "0.12.7"
+version = "0.12.8"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "0.12.6"
+version = "0.12.7"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Fix checks that are meant to run only on fastq files to make sure that the file format of the file is indeed fastq. This is necessary since we allowed also tar format for FileFastq items