### PR TITLE
EC2 WFR info

### DIFF
--- a/chalicelib/checks/system_checks.py
+++ b/chalicelib/checks/system_checks.py
@@ -872,7 +872,7 @@ def check_long_running_ec2s(connection, **kwargs):
                     ec2_log['active workflow runs'] = [wfr['@id'] for wfr in wfrs]
                 deleted_wfrs = ff_utils.search_metadata(search_url + '&status=deleted', key=connection.ff_keys)
                 if deleted_wfrs:
-                    ec2_log['deleted workflow runs'] = [wfr['@id'] for wfr in wfrs]
+                    ec2_log['deleted workflow runs'] = [wfr['@id'] for wfr in deleted_wfrs]
             # always add record to full_output; add to brief_output if
             # the instance is flagged based on 'Name' tag
             if created < fail_time:

--- a/chalicelib/checks/system_checks.py
+++ b/chalicelib/checks/system_checks.py
@@ -865,10 +865,13 @@ def check_long_running_ec2s(connection, **kwargs):
                 flag_instance = False
             # see if long running instances are associated with a deleted WFR
             if flag_instance and inst_name and created < warn_time:
-                search_url = 'search/?type=WorkflowRunAwsem&status=deleted&awsem_job_id='
+                search_url = 'search/?type=WorkflowRunAwsem&awsem_job_id='
                 search_url += '&awsem_job_id='.join([name[6:] for name in inst_name if name.startswith('awsem-')])
                 wfrs = ff_utils.search_metadata(search_url, key=connection.ff_keys)
                 if wfrs:
+                    ec2_log['active workflow runs'] = [wfr['@id'] for wfr in wfrs]
+                deleted_wfrs = ff_utils.search_metadata(search_url + '&status=deleted', key=connection.ff_keys)
+                if deleted_wfrs:
                     ec2_log['deleted workflow runs'] = [wfr['@id'] for wfr in wfrs]
             # always add record to full_output; add to brief_output if
             # the instance is flagged based on 'Name' tag

--- a/chalicelib/checks/system_checks.py
+++ b/chalicelib/checks/system_checks.py
@@ -863,6 +863,13 @@ def check_long_running_ec2s(connection, **kwargs):
                 flag_instance = True
             else:
                 flag_instance = False
+            # see if long running instances are associated with a deleted WFR
+            if flag_instance and inst_name and created < warn_time:
+                search_url = 'search/?type=WorkflowRunAwsem&status=deleted&awsem_job_id='
+                search_url += '&awsem_job_id='.join([name[6:] for name in inst_name if name.startswith('awsem-')])
+                wfrs = ff_utils.search_metadata(search_url, key=connection.ff_keys)
+                if wfrs:
+                    ec2_log['deleted workflow runs'] = [wfr['@id'] for wfr in wfrs]
             # always add record to full_output; add to brief_output if
             # the instance is flagged based on 'Name' tag
             if created < fail_time:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "0.12.8"
+version = "0.12.9"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
The check for long running EC2s now includes extra info in output indicating if there are deleted WFRs that the EC2 is associated with. This will make it quicker to figure out whether the EC2 needs to be terminated.

Example brief output:
```
{
  'one_week': [
    {
      'state': 'running', 
      'name': ['awsem-HxjGhj75z09i'], 
      'id': 'i-0e0e8b81b4176df36', 
      'type': 'c5.2xlarge', 
      'date_created_utc': '2020-08-28T21:01', 
      'deleted workflow runs': [
        '/workflow-runs-awsem/3e5c3b92-4d43-4483-af2f-fb6ae4b95a99/'
      ]
    }
  ], 
  'two_weeks': []
}
```