### PR TITLE
Url read timeout

### DIFF
--- a/chalicelib/checks/audit_checks.py
+++ b/chalicelib/checks/audit_checks.py
@@ -345,6 +345,7 @@ def check_help_page_urls(connection, **kwargs):
     results = help_results
     results = results + [item for item in resource_results if item['@id'] not in [res['@id'] for res in results]]
     sections_w_broken_links = {}
+    addl_exceptions = {}
     timeouts = {}
     for result in results:
         broken_links = []
@@ -383,6 +384,9 @@ def check_help_page_urls(connection, **kwargs):
                 timeouts[result['@id']].append(url)
             except requests.exceptions.SSLError:
                 continue
+            except Exception as e:
+                addl_exceptions.setdefault(result['@id'], {})
+                addl_exceptions[result['@id']][url] = e
         if broken_links:
             sections_w_broken_links[result['@id']] = broken_links
     if sections_w_broken_links:
@@ -396,7 +400,8 @@ def check_help_page_urls(connection, **kwargs):
         check.description = check.summary
     check.full_output = {
         'broken links': sections_w_broken_links,
-        'timed out requests': timeouts
+        'timed out requests': timeouts,
+        'additional exceptions': addl_exceptions
     }
     return check
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "0.12.9"
+version = "0.12.10"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
An additional exception was raised in the `check_help_page_urls` check not long ago. This PR adds an additional `except` statement to catch additional exceptions encountered during the call to `requests.get`.