### PR TITLE
Small fixes/optimizations

### DIFF
--- a/chalicelib/app_utils.py
+++ b/chalicelib/app_utils.py
@@ -376,6 +376,8 @@ def view_foursight(environ, is_admin=False, domain="", context="/"):
     view_envs = environments.keys() if environ == 'all' else [e.strip() for e in environ.split(',')]
     for this_environ in view_envs:
         try:
+            if 'cgap' in this_environ and not is_admin:  # no view permissions for non-admins on CGAP
+                continue
             connection = init_connection(this_environ, _environments=environments)
         except Exception:
             connection = None

--- a/chalicelib/app_utils.py
+++ b/chalicelib/app_utils.py
@@ -374,7 +374,6 @@ def view_foursight(environ, is_admin=False, domain="", context="/"):
     total_envs = []
     servers = []
     view_envs = environments.keys() if environ == 'all' else [e.strip() for e in environ.split(',')]
-    import pdb; pdb.set_trace()
     for this_environ in view_envs:
         try:
             connection = init_connection(this_environ, _environments=environments)

--- a/chalicelib/fs_connection.py
+++ b/chalicelib/fs_connection.py
@@ -38,7 +38,7 @@ class FSConnection(object):
         self.ff_es = fs_environ_info['es']
         if not test:
             self.ff_s3 = s3Utils(env=self.ff_env)
-            try:
+            try:  # TODO: make this configurable from env variables?
                 self.ff_keys = self.ff_s3.get_access_keys('access_key_foursight')
             except Exception as e:
                 raise Exception('Could not initiate connection to Fourfront; it is probably a bad ff_env. '

--- a/poetry.lock
+++ b/poetry.lock
@@ -52,10 +52,10 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = "*"
-version = "1.14.60"
+version = "1.14.62"
 
 [package.dependencies]
-botocore = ">=1.17.60,<1.18.0"
+botocore = ">=1.17.62,<1.18.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
@@ -65,7 +65,7 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = "*"
-version = "1.17.60"
+version = "1.17.62"
 
 [package.dependencies]
 docutils = ">=0.10,<0.16"
@@ -160,7 +160,7 @@ description = "Utility package for interacting with the 4DN Data Portal and othe
 name = "dcicutils"
 optional = false
 python-versions = ">=3.4,<3.8"
-version = "1.0.0b1"
+version = "1.1.0b1"
 
 [package.dependencies]
 aws-requests-auth = ">=0.4.2,<1"
@@ -315,7 +315,7 @@ description = "Google Authentication Library"
 name = "google-auth"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
-version = "1.21.1"
+version = "1.21.2"
 
 [package.dependencies]
 cachetools = ">=2.0.0,<5.0"
@@ -762,7 +762,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "75dee48f488663b4f35b32182346b6efee65bfb1be0a87e64ac972974fa4f2df"
+content-hash = "a841ba8bb3df27eadd64f73bd514d9f19adbc80ae4786023f1bdb6d037455a6c"
 python-versions = ">=3.6,<3.7"
 
 [metadata.files]
@@ -784,12 +784,12 @@ beautifulsoup4 = [
     {file = "beautifulsoup4-4.9.1.tar.gz", hash = "sha256:73cc4d115b96f79c7d77c1c7f7a0a8d4c57860d1041df407dd1aae7f07a77fd7"},
 ]
 boto3 = [
-    {file = "boto3-1.14.60-py2.py3-none-any.whl", hash = "sha256:79e95f428c485ea817969a78e77a311d2ec4d82e0955639d6126189c990ddad3"},
-    {file = "boto3-1.14.60.tar.gz", hash = "sha256:d8ca27ee13deeb1a9e79f2fe5f923effa60947ed49bbdfbc2a9f5790aef64217"},
+    {file = "boto3-1.14.62-py2.py3-none-any.whl", hash = "sha256:74e0058e373d64e23dea639fc7bcd3d83d08e091a044f32513d13cc4a03d7fe5"},
+    {file = "boto3-1.14.62.tar.gz", hash = "sha256:2bead722a2b91d11faad0479eadf57283c864a40687100d0f5829e6a4242ccb1"},
 ]
 botocore = [
-    {file = "botocore-1.17.60-py2.py3-none-any.whl", hash = "sha256:e55a4fc652537f5ccb2362133f3928ebeafb04ee9fe15ea11c2df80ba4ef8a12"},
-    {file = "botocore-1.17.60.tar.gz", hash = "sha256:193f193a66ac79106725e14dd73e28ed36bcec99b37156538a2202d061056a58"},
+    {file = "botocore-1.17.62-py2.py3-none-any.whl", hash = "sha256:a47ec927517403c6711f0cf7c51207f45b5aa4875791527a395a6402bd146514"},
+    {file = "botocore-1.17.62.tar.gz", hash = "sha256:8712b69f6e4abd9a5ef52b20fb5b9ca545cda335ee1b106fc68dd7786c7c78ae"},
 ]
 cachetools = [
     {file = "cachetools-4.1.1-py3-none-any.whl", hash = "sha256:513d4ff98dd27f85743a8dc0e92f55ddb1b49e060c2d5961512855cda2c01a98"},
@@ -852,8 +852,8 @@ coverage = [
     {file = "coverage-5.3.tar.gz", hash = "sha256:280baa8ec489c4f542f8940f9c4c2181f0306a8ee1a54eceba071a449fb870a0"},
 ]
 dcicutils = [
-    {file = "dcicutils-1.0.0b1-py3-none-any.whl", hash = "sha256:bb86f19e5e6ff114b4690a5317d6c7c1919085324f81021840588b3d9c58b965"},
-    {file = "dcicutils-1.0.0b1.tar.gz", hash = "sha256:94f2e5550f40e523cec61c5b5a82605fdd5104b2881d5acd6193af6351a946aa"},
+    {file = "dcicutils-1.1.0b1-py3-none-any.whl", hash = "sha256:6b02b36491fb48fd06d2d552fb09ebb3d7c2cfe488fa5626226f2169f4f2f8cb"},
+    {file = "dcicutils-1.1.0b1.tar.gz", hash = "sha256:85e71daca60106cc49d03ee40fe7673da19352b37195cd8da5821ab8de55ca36"},
 ]
 decorator = [
     {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
@@ -904,8 +904,8 @@ google-api-python-client = [
     {file = "google_api_python_client-1.7.4-py3-none-any.whl", hash = "sha256:7cc47cf80b25ecd7f3d917ea247bb6c62587514e40604ae29c47c0e4ebd1174b"},
 ]
 google-auth = [
-    {file = "google-auth-1.21.1.tar.gz", hash = "sha256:bcbd9f970e7144fe933908aa286d7a12c44b7deb6d78a76871f0377a29d09789"},
-    {file = "google_auth-1.21.1-py2.py3-none-any.whl", hash = "sha256:f4d5093f13b1b1c0a434ab1dc851cd26a983f86a4d75c95239974e33ed406a87"},
+    {file = "google-auth-1.21.2.tar.gz", hash = "sha256:7084c50c03f7a8a5696ef4500e65df0c525a0f6909f3c70b9ee65900a230c755"},
+    {file = "google_auth-1.21.2-py2.py3-none-any.whl", hash = "sha256:dcf86c5adc3a8a7659be190b12bb8912ae019cfd9ee2a571ea881e289fafbe39"},
 ]
 google-auth-httplib2 = [
     {file = "google-auth-httplib2-0.0.4.tar.gz", hash = "sha256:8d092cc60fb16517b12057ec0bba9185a96e3b7169d86ae12eae98e645b7bc39"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.1.0"
+version = "1.1.1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.6,<3.7"
-dcicutils = "1.0.0b1"
+dcicutils = "1.1.0b1"
 click = "6.7"
 PyJWT = "1.5.3"
 Jinja2 = "2.10.1"

--- a/tests/test_app_utils.py
+++ b/tests/test_app_utils.py
@@ -24,7 +24,7 @@ class TestAppUtils():
 
     def test_get_favicon(self):
         """ Tests that given 'mastertest' we get the right url for favicon """
-        expected = self.conn.ff_server + 'static/img/favicon-fs.ico'
+        expected = 'https://data.4dnucleome.org/static/img/favicon-fs.ico'
         actual = app_utils.get_favicon(self.conn.ff_server)
         assert expected == actual
 

--- a/tests/test_app_utils.py
+++ b/tests/test_app_utils.py
@@ -2,6 +2,8 @@ from conftest import *
 import json
 import boto3
 from botocore.exceptions import ClientError
+from dcicutils.env_utils import FF_PUBLIC_URL_PRD
+
 
 class TestAppUtils():
     """
@@ -24,7 +26,7 @@ class TestAppUtils():
 
     def test_get_favicon(self):
         """ Tests that given 'mastertest' we get the right url for favicon """
-        expected = 'https://data.4dnucleome.org/static/img/favicon-fs.ico'
+        expected = FF_PUBLIC_URL_PRD + '/static/img/favicon-fs.ico'  # favicon acquired from prod
         actual = app_utils.get_favicon(self.conn.ff_server)
         assert expected == actual
 


### PR DESCRIPTION
- Use HTTPS for favicon always
- Use get_size instead of json.dumps, which should be faster
- Disable view permissions on CGAP envs for not-logged in users

When not logged in: https://kpqxwgx646.execute-api.us-east-1.amazonaws.com/api/view/cgapdev is now indistinguishable from https://kpqxwgx646.execute-api.us-east-1.amazonaws.com/api/view/blahblah