### PR TITLE
C4-314 Misc Check Fixes

### DIFF
--- a/chalicelib/app_utils.py
+++ b/chalicelib/app_utils.py
@@ -449,7 +449,7 @@ def view_foursight_check(environ, check, uuid, is_admin=False, domain="", contex
                 data = {
                     'name': check,
                     'uuid': uuid,
-                    'status': 'ERROR',
+                    'status': 'ERROR',  # in this case we just queued a check, so ERROR is ok
                     'summary': 'Check has not yet run',
                     'description': 'Check has not yet run'
                 }

--- a/chalicelib/check_utils.py
+++ b/chalicelib/check_utils.py
@@ -347,7 +347,7 @@ def create_placeholder_check(check_name):
         'name': check_name,
         'uuid': _uuid,
         'kwargs': {'uuid': _uuid, 'primary': True},
-        'status': 'WARN',
+        'status': 'PASS',  # so these show up green
         'summary': 'Check has not yet run',
         'description': 'If queued, this check will run with default arguments'
     }

--- a/chalicelib/checks/deployment_checks.py
+++ b/chalicelib/checks/deployment_checks.py
@@ -47,7 +47,7 @@ def cleanup_tempdir(tempdir):
     shutil.rmtree(tempdir)
 
 
-def are_counts_are_even(env):
+def are_counts_even(env):
     """ From dcicutils - to be ported over in this form at some point. """
     try:
         totals = get_metadata('/counts', ff_env=env)['db_es_total'].split()
@@ -79,7 +79,7 @@ def indexer_server_status(connection, **kwargs):
         return check
 
     try:
-        indexing_finished, counts = are_counts_are_even(env)
+        indexing_finished, counts = are_counts_even(env)
     except Exception as e:  # XXX: This should be handled in dcicutils -Will 5/18/2020
         check.status = 'ERROR'
         check.summary = 'Failed to get indexing status of given env: %s' % str(e)

--- a/chalicelib/checks/release_updates_checks.py
+++ b/chalicelib/checks/release_updates_checks.py
@@ -437,9 +437,10 @@ def experiment_set_reporting_data(connection, **kwargs):
     return check
 
 
-@check_function(start_date=None, end_date=None, update_tag='DISCARD', tag_filter=None, project_filter='4DN', is_internal=False)
-def data_release_updates(connection, **kwargs):
+def _old_data_release_updates(connection, **kwargs):
     """
+    OLD VERSION of the data_release_updates check with docstring.
+
     Diff two results of 'experiment_set_reporting_data' check.
 
     start_date and end_date are dates in form YYYY-MM-DD.
@@ -486,7 +487,7 @@ def data_release_updates(connection, **kwargs):
         end_data_result = data_check.get_closest_result(override_date=end_date)
     else:  # use primary result if end_data_result is not supplied
         end_data_result = data_check.get_primary_result()
-        end_date_str = end_data_result['uuid'][:10] #YYYY-MM-DD
+        end_date_str = end_data_result['uuid'][:10]  # YYYY-MM-DD
     # start_date must be before end_date
     if start_date_str > end_date_str:
         check.status = 'ERROR'
@@ -498,7 +499,9 @@ def data_release_updates(connection, **kwargs):
         return check
     tag_filter = kwargs['tag_filter']
     project_filter = kwargs.get('project_filter')
-    used_res_strings = ' Compared results from %s (start) to %s (end). UUIDs are %s (start) and %s (end). Used filter on replicate sets tag is %s and the filter on award.project is %s (None means no filter in both cases).' % (start_date_str, end_date_str, start_data_result.get('uuid', 'None'), end_data_result['uuid'], tag_filter, project_filter)
+    used_res_strings = ' Compared results from %s (start) to %s (end). UUIDs are %s (start) and %s (end). Used filter on replicate sets tag is %s and the filter on award.project is %s (None means no filter in both cases).' % (
+    start_date_str, end_date_str, start_data_result.get('uuid', 'None'), end_data_result['uuid'], tag_filter,
+    project_filter)
     start_output = start_data_result.get('full_output', {})  # this can be empty
     end_output = end_data_result.get('full_output')  # this cannot be empty
     if not isinstance(start_output, dict) or not isinstance(end_output, dict):
@@ -575,7 +578,7 @@ def data_release_updates(connection, **kwargs):
         group_report['award'] = '1U01CA200059-01'
         group_report['status'] = 'released'
         group_report['is_internal'] = kwargs['is_internal']
-        for gr in group: # iterate through the rest of the items
+        for gr in group:  # iterate through the rest of the items
             group_report['update_items'].append({'primary_id': gr['set_@id'], 'secondary_ids': gr['items']})
         group_reports.append(group_report)
     # update summaries for plural cases
@@ -589,7 +592,9 @@ def data_release_updates(connection, **kwargs):
     static_proj = project_filter if project_filter else ''
     static_scope = 'network members' if kwargs['is_internal'] else 'public'
     static_tag = 'with %s tag' % tag_filter if tag_filter else ''
-    static_content = ' '.join(['All', static_proj, 'data released to', static_scope, 'between', start_date_str, 'and', end_date_str, static_tag])
+    static_content = ' '.join(
+        ['All', static_proj, 'data released to', static_scope, 'between', start_date_str, 'and', end_date_str,
+         static_tag])
     report_static_section = {
         'name': 'release-updates.' + kwargs['update_tag'],
         'body': '<h4 style=\"margin-top:0px;font-weight:400\">' + static_content + '</h4>'
@@ -601,7 +606,8 @@ def data_release_updates(connection, **kwargs):
             'static_section': report_static_section
         }
         check.description = 'Ready to publish new data release updates.' + used_res_strings
-        check.action_message = 'Will publish %s  grouped updates with the update_tag: %s. See brief_output.' % ( str(len(group_reports)), kwargs['update_tag'])
+        check.action_message = 'Will publish %s  grouped updates with the update_tag: %s. See brief_output.' % (
+        str(len(group_reports)), kwargs['update_tag'])
         check.allow_action = True
     else:
         check.brief_output = {
@@ -612,8 +618,18 @@ def data_release_updates(connection, **kwargs):
     return check
 
 
-@action_function()
+@check_function(start_date=None, end_date=None, update_tag='DISCARD', tag_filter=None, project_filter='4DN', is_internal=False)
+def data_release_updates(connection, **kwargs):
+    """ TODO: New version of this check - for now, does nothing - see old version above. """
+    check = CheckResult(connection, 'data_release_updates')
+    check.status = 'PASS'
+    check.brief_output = check.full_output = 'This check still needs to be implemented!'
+    return check
+
+
+@action_function
 def publish_data_release_updates(connection, **kwargs):
+    """ TODO: This action probably needs rewriting as well as it based on the OLD data_release_updates check. """
     action = ActionResult(connection, 'publish_data_release_updates')
     report_result = action.get_associated_check_result(kwargs)
     action.description = "Publish data release updates to Fourfront."
@@ -636,7 +652,6 @@ def publish_data_release_updates(connection, **kwargs):
     }
     action.status = 'DONE'
     return action
-
 
 
 @check_function(start_date=None, end_date=None)

--- a/chalicelib/checks/system_checks.py
+++ b/chalicelib/checks/system_checks.py
@@ -21,7 +21,7 @@ import time
 
 
 # XXX: put into utils?
-CGAP_TEST_CLUSTER = 'search-cgap-testing-ud3ggpjj7x6vclx62nmzymyzfi.us-east-1.es.amazonaws.com:80'
+CGAP_TEST_CLUSTER = 'search-cgap-testing-6-8-vo4mdkmkshvmyddc65ux7dtaou.us-east-1.es.amazonaws.com:443'
 FF_TEST_CLUSTER = 'search-fourfront-testing-6-8-kncqa2za2r43563rkcmsvgn2fq.us-east-1.es.amazonaws.com:443'
 TEST_ES_CLUSTERS = [
     CGAP_TEST_CLUSTER,
@@ -30,34 +30,31 @@ TEST_ES_CLUSTERS = [
 BUILD_INDICES_REGEX = re.compile('^[0-9]')  # build indices are prefixed by numbers
 
 
-def wipe_build_indices(connection, es_url):
+def wipe_build_indices(es_url, check):
     """ Wipes all number-prefixed indices on the given es_url. Be careful not to run while
         builds are running as this will cause them to fail.
     """
-    check = CheckResult(connection, 'wipe_build_indices')
     check.status = 'PASS'
     check.summary = check.description = 'Wiped all test indices on url: %s' % es_url
     client = es_utils.create_es_client(es_url, True)
     full_output = []
     _, indices = cat_indices(client)  # index name is index 2 in row
-    # XXX: Commented out so we can see if the below logic is what is causing timeout on
-    # foursight.
-    # for index in indices:
-    #     try:
-    #         index_name = index[2]
-    #     except IndexError:  # empty [] sometimes returned by API call
-    #         continue
-    #     if re.match(BUILD_INDICES_REGEX, index_name) is not None:
-    #         try:
-    #             resp = Retry.retrying(client.indices.delete, retries_allowed=3)(index=index_name)
-    #         except Exception as e:
-    #             full_output.append({'acknowledged': True, 'error': str(e)})
-    #         else:
-    #             full_output.append(resp)
-    #
-    # if any(output['acknowledged'] is not True for output in full_output):
-    #     check.status = 'FAIL'
-    #     check.summary = check.description = 'Failed to wipe all test indices, see full output'
+    for index in indices:
+        try:
+            index_name = index[2]
+        except IndexError:  # empty [] sometimes returned by API call
+            continue
+        if re.match(BUILD_INDICES_REGEX, index_name) is not None:
+            try:
+                resp = Retry.retrying(client.indices.delete, retries_allowed=3)(index=index_name)
+            except Exception as e:
+                full_output.append({'acknowledged': True, 'error': str(e)})
+            else:
+                full_output.append(resp)
+
+    if any(output['acknowledged'] is not True for output in full_output):
+        check.status = 'FAIL'
+        check.summary = check.description = 'Failed to wipe all test indices, see full output'
     check.full_output = full_output
     return check
 
@@ -65,13 +62,15 @@ def wipe_build_indices(connection, es_url):
 @check_function()
 def wipe_cgap_build_indices(connection, **kwargs):
     """ Wipes build indices for CGAP (on cgap-testing) """
-    return wipe_build_indices(connection, CGAP_TEST_CLUSTER)
+    check = CheckResult(connection, 'wipe_cgap_build_indices')
+    return wipe_build_indices(CGAP_TEST_CLUSTER, check)
 
 
 @check_function()
 def wipe_ff_build_indices(connection, **kwargs):
     """ Wipes build (number prefixed) indices (on fourfront-testing) """
-    return wipe_build_indices(connection, FF_TEST_CLUSTER)
+    check = CheckResult(connection, 'wipe_ff_build_indices')
+    return wipe_build_indices(FF_TEST_CLUSTER, check)
 
 
 @check_function()

--- a/chalicelib/checks/system_checks.py
+++ b/chalicelib/checks/system_checks.py
@@ -40,22 +40,24 @@ def wipe_build_indices(connection, es_url):
     client = es_utils.create_es_client(es_url, True)
     full_output = []
     _, indices = cat_indices(client)  # index name is index 2 in row
-    for index in indices:
-        try:
-            index_name = index[2]
-        except IndexError:  # empty [] sometimes returned by API call
-            continue
-        if re.match(BUILD_INDICES_REGEX, index_name) is not None:
-            try:
-                resp = Retry.retrying(client.indices.delete, retries_allowed=3)(index=index_name)
-            except Exception as e:
-                full_output.append({'acknowledged': True, 'error': str(e)})
-            else:
-                full_output.append(resp)
-
-    if any(output['acknowledged'] is not True for output in full_output):
-        check.status = 'FAIL'
-        check.summary = check.description = 'Failed to wipe all test indices, see full output'
+    # XXX: Commented out so we can see if the below logic is what is causing timeout on
+    # foursight.
+    # for index in indices:
+    #     try:
+    #         index_name = index[2]
+    #     except IndexError:  # empty [] sometimes returned by API call
+    #         continue
+    #     if re.match(BUILD_INDICES_REGEX, index_name) is not None:
+    #         try:
+    #             resp = Retry.retrying(client.indices.delete, retries_allowed=3)(index=index_name)
+    #         except Exception as e:
+    #             full_output.append({'acknowledged': True, 'error': str(e)})
+    #         else:
+    #             full_output.append(resp)
+    #
+    # if any(output['acknowledged'] is not True for output in full_output):
+    #     check.status = 'FAIL'
+    #     check.summary = check.description = 'Failed to wipe all test indices, see full output'
     check.full_output = full_output
     return check
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.1.1"
+version = "1.1.2"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/tests/test_check_utils.py
+++ b/tests/test_check_utils.py
@@ -271,5 +271,5 @@ class TestCheckUtils():
         """ Tests that placeholder checks are properly generated """
         placeholder = check_utils.create_placeholder_check('test_check')
         assert placeholder['name'] == 'test_check'
-        assert placeholder['status'] == 'WARN'
+        assert placeholder['status'] == 'PASS'
         assert placeholder['description'] == 'If queued, this check will run with default arguments'

--- a/tests/test_check_utils.py
+++ b/tests/test_check_utils.py
@@ -232,7 +232,6 @@ class TestCheckUtils():
         assert (assc_check['name'] == act_kwargs['check_name'])
         assert (assc_check['uuid'] == act_uuid)
 
-
     def test_run_check_errors(self):
         bad_check_group = [
             ['indexing_progress', {}, [], 'xx1'],


### PR DESCRIPTION
- Checks that have not run now show up as green
- Data release update check + action disabled/marked for reimplementation
- Allow indexer server status check to go green in a default scenario
- Replace `is_indexing_finished` (obsolete) with `are_counts_even`
- Fix wipe_build_indices check