### PR TITLE
Cgap v17

### DIFF
--- a/chalicelib/checks/helpers/cgap_utils.py
+++ b/chalicelib/checks/helpers/cgap_utils.py
@@ -102,6 +102,10 @@ workflow_details = {
         "run_time": 12,
         "accepted_versions": ["v13", "v15", "v16"]
     },
+    "workflow_vep-parallel": {
+        "run_time": 12,
+        "accepted_versions": ["v17"]
+    },
     "workflow_mutanno-micro-annot-check": {
         "run_time": 12,
         "accepted_versions": ["v16"]

--- a/chalicelib/checks/helpers/cgap_utils.py
+++ b/chalicelib/checks/helpers/cgap_utils.py
@@ -24,31 +24,31 @@ workflow_details = {
     },
     "workflow_bwa-mem_no_unzip-check": {
         "run_time": 12,
-        "accepted_versions": ["v10", "v11", "v12", "v13", "v15", "v16"]
+        "accepted_versions": ["v10", "v11", "v12", "v13", "v15", "v16", "v17"]
     },
     "workflow_add-readgroups-check": {
         "run_time": 12,
-        "accepted_versions": ["v10", "v11", "v12", "v13", "v15", "v16"]
+        "accepted_versions": ["v10", "v11", "v12", "v13", "v15", "v16", "v17"]
     },
     "workflow_merge-bam-check": {
         "run_time": 12,
-        "accepted_versions": ["v9", "v10", "v11", "v12", "v13", "v15", "v16"]
+        "accepted_versions": ["v9", "v10", "v11", "v12", "v13", "v15", "v16", "v17"]
     },
     "workflow_picard-MarkDuplicates-check": {
         "run_time": 12,
-        "accepted_versions": ["v9", "v10", "v11", "v12", "v13", "v15", "v16"]
+        "accepted_versions": ["v9", "v10", "v11", "v12", "v13", "v15", "v16", "v17"]
     },
     "workflow_sort-bam-check": {
         "run_time": 12,
-        "accepted_versions": ["v9", "v10", "v11", "v12", "v13", "v15", "v16"]
+        "accepted_versions": ["v9", "v10", "v11", "v12", "v13", "v15", "v16", "v17"]
     },
     "workflow_gatk-BaseRecalibrator": {
         "run_time": 12,
-        "accepted_versions": ["v9", "v10", "v11", "v12", "v13", "v15", "v16"]
+        "accepted_versions": ["v9", "v10", "v11", "v12", "v13", "v15", "v16", "v17"]
     },
     "workflow_gatk-ApplyBQSR-check": {
         "run_time": 12,
-        "accepted_versions": ["v9", "v10", "v11", "v12", "v13", "v15", "v16"]
+        "accepted_versions": ["v9", "v10", "v11", "v12", "v13", "v15", "v16", "v17"]
     },
     # defunct step 8
     "workflow_index-sorted-bam": {
@@ -57,17 +57,17 @@ workflow_details = {
     },
     "workflow_granite-mpileupCounts": {
         "run_time": 12,
-        "accepted_versions": ["v14", "v15", "v16"]
+        "accepted_versions": ["v14", "v15", "v16", "v17"]
     },
     # new step 8
     'workflow_gatk-HaplotypeCaller': {
         "run_time": 12,
-        "accepted_versions": ["v10", "v11", "v12", "v13", "v15", "v16"]
+        "accepted_versions": ["v10", "v11", "v12", "v13", "v15", "v16", "v17"]
     },
     # step 9
     'workflow_granite-mpileupCounts': {
         "run_time": 12,
-        "accepted_versions": ["v14", "v15", "v16"]
+        "accepted_versions": ["v14", "v15", "v16", "v17"]
     },
     # step 10
     'cgap-bamqc': {
@@ -78,12 +78,12 @@ workflow_details = {
     # part II step 1
     'workflow_gatk-CombineGVCFs': {
         "run_time": 12,
-        "accepted_versions": ["v10", "v11", "v12", "v13", "v15", "v16"]
+        "accepted_versions": ["v10", "v11", "v12", "v13", "v15", "v16", "v17"]
     },
     # part II step 2
     'workflow_gatk-GenotypeGVCFs-check': {
         "run_time": 12,
-        "accepted_versions": ["v10", "v11", "v12", "v13", "v15", "v16"]
+        "accepted_versions": ["v10", "v11", "v12", "v13", "v15", "v16", "v17"]
     },
     # part III step 3
     'workflow_gatk-VQSR-check': {
@@ -96,11 +96,11 @@ workflow_details = {
     },
     "workflow_cram2fastq": {
         "run_time": 12,
-        "accepted_versions": ["v12", "v13", "v15", "v16"]
+        "accepted_versions": ["v12", "v13", "v15", "v16", "v17"]
     },
     "workflow_cram2bam-check": {
         "run_time": 12,
-        "accepted_versions": ["v13", "v15", "v16"]
+        "accepted_versions": ["v13", "v15", "v16", "v17"]
     },
     "workflow_vep-parallel": {
         "run_time": 12,
@@ -108,32 +108,32 @@ workflow_details = {
     },
     "workflow_mutanno-micro-annot-check": {
         "run_time": 12,
-        "accepted_versions": ["v16"]
+        "accepted_versions": ["v16", "v17"]
     },
     # Part III
     "workflow_granite-rckTar": {
         "run_time": 12,
-        "accepted_versions": ["v16"]
+        "accepted_versions": ["v16", "v17"]
     },
     "workflow_granite-filtering-check": {
         "run_time": 12,
-        "accepted_versions": ['v16']
+        "accepted_versions": ["v16", "v17"]
     },
     "workflow_granite-novoCaller-rck-check": {
         "run_time": 12,
-        "accepted_versions": ["v16"]
+        "accepted_versions": ["v16", "v17"]
     },
     "workflow_granite-comHet-check": {
         "run_time": 12,
-        "accepted_versions": ["v16"]
+        "accepted_versions": ["v16", "v17"]
     },
     "workflow_mutanno-annot-check": {
         "run_time": 12,
-        "accepted_versions": ["v16"]
+        "accepted_versions": ["v16", "v17"]
     },
     "bamsnap": {
         "run_time": 12,
-        "accepted_versions": ["v14", "v15", "v16"]
+        "accepted_versions": ["v14", "v15", "v16", "v17"]
     },
     "workflow_granite-qcVCF": {
         "run_time": 12,

--- a/chalicelib/checks/helpers/cgap_utils.py
+++ b/chalicelib/checks/helpers/cgap_utils.py
@@ -102,12 +102,12 @@ workflow_details = {
         "run_time": 12,
         "accepted_versions": ["v13", "v15", "v16"]
     },
-    # Part III
-    "workflow_granite-rckTar": {
+    "workflow_mutanno-micro-annot-check": {
         "run_time": 12,
         "accepted_versions": ["v16"]
     },
-    "workflow_mutanno-micro-annot-check": {
+    # Part III
+    "workflow_granite-rckTar": {
         "run_time": 12,
         "accepted_versions": ["v16"]
     },

--- a/chalicelib/checks/helpers/cgap_utils.py
+++ b/chalicelib/checks/helpers/cgap_utils.py
@@ -4,7 +4,8 @@ from operator import itemgetter
 from . import wfrset_cgap_utils
 import json
 lambda_limit = wfrset_cgap_utils.lambda_limit
-
+# use wf_dict in workflow version check to make sure latest version and workflow uuid matches
+wf_dict = wfrset_cgap_utils.wf_dict
 # check at the end
 # check extract_file_info has 4 arguments
 
@@ -249,6 +250,12 @@ def check_latest_workflow_version(workflows):
         if last_version not in all_wf_versions:
             err = '{} version {} is not on any wf app_version)'.format(wf_name, last_version)
             errors.append(err)
+            continue
+        # if it is , check the uuids on wfr_dict and the workflow item match
+        latest_workflow_uuid = [i['uuid'] for i in workflows if i['app_version'] == last_version][0]
+        wf_dict_item = [i['workflow_uuid'] for i in wf_dict if i['app_name'] == wf_name][0]
+        if latest_workflow_uuid != wf_dict_item:
+            err = '{} item on wf_dict does not have the latest workflow uuid'.format(wf_name)
     return errors
 
 # accepted versions for completed pipelines

--- a/chalicelib/checks/helpers/cgap_utils.py
+++ b/chalicelib/checks/helpers/cgap_utils.py
@@ -251,7 +251,7 @@ def check_latest_workflow_version(workflows):
             err = '{} version {} is not on any wf app_version)'.format(wf_name, last_version)
             errors.append(err)
             continue
-        # if it is , check the uuids on wfr_dict and the workflow item match
+        # check if the lastest version workflow uuids is correct on wfr_dict (wfrset_cgap_utils.py)
         latest_workflow_uuid = [i['uuid'] for i in workflows if i['app_version'] == last_version][0]
         wf_dict_item = [i['workflow_uuid'] for i in wf_dict if i['app_name'] == wf_name][0]
         if latest_workflow_uuid != wf_dict_item:

--- a/chalicelib/checks/helpers/wfrset_cgap_utils.py
+++ b/chalicelib/checks/helpers/wfrset_cgap_utils.py
@@ -10,6 +10,426 @@ pairs_mapper = {"GRCh38": "hg38",
                 "dm6": 'dm6',
                 "galGal5": "galGal5"}
 
+wf_dict = [
+    {
+        'app_name': 'md5',
+        'workflow_uuid': 'c77a117b-9a58-477e-aaa5-291a109a99f6',
+        "config": {"ebs_size": 10}
+    },
+    {
+        'app_name': 'fastqc',
+        'workflow_uuid': '49e96b51-ed6c-4418-a693-d0e9f79adfa5',
+        "config": {
+            "ebs_size": 10,
+            "instance_type": 't3.micro',
+            'EBS_optimized': True
+            }
+    },
+    {  # cram to fastq converter
+        'app_name': 'workflow_cram2fastq',
+        'workflow_uuid': '7bbf3487-a1fc-4073-952a-d5771973e875',
+        'parameters': {},
+        "config": {
+            "instance_type": "c5.4xlarge",
+            "ebs_size": "30x",
+            "EBS_optimized": True
+        },
+        'custom_pf_fields': {
+            'fastq1': {
+                'file_type': 'reads',
+                'description': 'Fastq files produced from CRAM files - paired end:1'},
+            'fastq2': {
+                'file_type': 'reads',
+                'description': 'Fastq files produced from CRAM files - paired end:2'}
+                }
+    },
+    {  # cram to bam converter
+        'app_name': 'workflow_cram2bam-check',
+        'workflow_uuid': '2a086f2b-7be4-4708-9516-1b39639292bf',
+        'parameters': {},
+        "config": {
+            "instance_type": "c5.2xlarge",
+            "ebs_size": "4.5x",
+            "EBS_optimized": True
+        },
+        'custom_pf_fields': {
+            'converted_bam': {
+                'file_type': 'alignments',
+                'description': 'BAM file converted from CRAM file'
+            }
+        }
+    },
+    # http://patorjk.com/software/taag/#p=display&v=1&f=Graceful&t=QC
+    #   __    ___
+    #  /  \  / __)
+    # (  O )( (__
+    #  \__\) \___)
+    {
+       "app_name": "workflow_qcboard-bam",
+       "parameters": {},
+       "workflow_uuid": "ad8716a3-b6e8-4021-bbc6-b0cefc9c4dd8",
+       "config": {
+         "instance_type": "t3.medium",
+         "ebs_size": "1.3x",
+         "EBS_optimized": True
+       }
+    },
+    #  ____   __   ____  ____    __
+    # (  _ \ / _\ (  _ \(_  _)  (  )
+    #  ) __//    \ )   /  )(     )(
+    # (__)  \_/\_/(__\_) (__)   (__)
+    # step1
+    {
+        'app_name': 'workflow_bwa-mem_no_unzip-check',
+        'workflow_uuid': '50e75343-2e00-471d-a667-4acb083287d8',
+        'parameters': {},
+        "config": {
+            "instance_type": "c5n.18xlarge",
+            "ebs_size": "5x",
+            "EBS_optimized": True,
+            "behavior_on_capacity_limit": "wait_and_retry"
+            },
+        'custom_pf_fields': {
+            'raw_bam': {
+                'file_type': 'intermediate file',
+                'description': 'Intermediate alignment file'}
+                }
+    },
+    # step2
+    {
+        'app_name': 'workflow_add-readgroups-check',
+        'workflow_uuid': 'd554d59b-e709-4c35-a81f-68a0cb3dd38a',
+        'parameters': {},
+        "config": {
+            "instance_type": "c5.2xlarge",
+            "ebs_size": "2.2x",
+            "EBS_optimized": True,
+            "behavior_on_capacity_limit": "wait_and_retry"
+            },
+        'custom_pf_fields': {
+            'bam_w_readgroups': {
+                'file_type': 'intermediate file',
+                'description': 'Intermediate alignment file'}
+                }
+    },
+    # step3
+    {
+        'app_name': 'workflow_merge-bam-check',
+        'workflow_uuid': '4853a03a-8c0c-4624-a45d-c5206a72907b',
+        'parameters': {},
+        "config": {
+            "instance_type": "c5.2xlarge",
+            "ebs_size": "2.2x",
+            "EBS_optimized": True,
+            "behavior_on_capacity_limit": "wait_and_retry"
+        },
+        'custom_pf_fields': {
+            'merged_bam': {
+                'file_type': 'intermediate file',
+                'description': 'Intermediate alignment file'}
+                }
+    },
+    {  # step 4
+        'app_name': 'workflow_picard-MarkDuplicates-check',
+        'workflow_uuid': 'beb2b340-94ee-4afe-b4e3-66caaf063397',
+        'parameters': {},
+        "config": {
+            "instance_type": "c5n.18xlarge",
+            "ebs_size": "3x",
+            "EBS_optimized": True,
+            "behavior_on_capacity_limit": "wait_and_retry"
+        },
+        'custom_pf_fields': {
+            'dupmarked_bam': {
+                'file_type': 'intermediate file',
+                'description': 'Intermediate alignment file'}
+                }
+    },
+    {  # step 5
+        'app_name': 'workflow_sort-bam-check',
+        'workflow_uuid': '560f5194-cd3a-4799-9b1a-6a2d2c371c89',
+        'parameters': {},
+        "config": {
+            "instance_type": "m5a.2xlarge",
+            "ebs_size": "3.2x",
+            "EBS_optimized": True,
+            "behavior_on_capacity_limit": "wait_and_retry"
+        },
+        'custom_pf_fields': {
+            'sorted_bam': {
+                'file_type': 'intermediate file',
+                'description': 'Intermediate alignment file'}
+                }
+    },
+    {  # step 6
+        'app_name': 'workflow_gatk-BaseRecalibrator',
+        'workflow_uuid': '455b3056-64ca-4a9b-b546-294b01c9ca92',
+        'parameters': {},
+        "config": {
+            "instance_type": "t3.small",
+            "ebs_size": "2x",
+            "EBS_optimized": True,
+            "behavior_on_capacity_limit": "wait_and_retry"
+        },
+        'custom_pf_fields': {
+            'recalibration_report': {
+                'file_type': 'intermediate file',
+                'description': 'Intermediate alignment file'}
+                }
+    },
+    {  # step 7
+        'app_name': 'workflow_gatk-ApplyBQSR-check',
+        'workflow_uuid': '6c9c6f49-f954-4e76-8dfb-d385cddcebd6',
+        'parameters': {},
+        "config": {
+            "instance_type": "t3.micro",
+            "ebs_size": "2.5x",
+            "EBS_optimized": True,
+            "behavior_on_capacity_limit": "wait_and_retry"
+        },
+        'custom_pf_fields': {
+            'recalibrated_bam': {
+                'file_type': 'alignments',
+                'description': 'processed output from cgap upstream pipeline'}
+                }
+    },
+    # part 1 - step 8   (only run for samples that will go to part3)
+    {  # mpileupCounts
+        'app_name': 'workflow_granite-mpileupCounts',
+        'workflow_uuid': 'c6dac0af-631d-402f-a1c1-282e091f1b3e',
+        'parameters': {"nthreads": 15},
+        "config": {
+            "instance_type": "c5.4xlarge",
+            "ebs_size": 120,
+            "EBS_optimized": True
+        },
+        'custom_pf_fields': {
+            'rck': {
+                'file_type': 'read counts (rck)',
+                'description': 'read counts (rck) file'
+            }
+        }
+    },
+    # step 9
+    {
+        'app_name': 'workflow_gatk-HaplotypeCaller',
+        'workflow_uuid': '7fd67e19-3425-45f8-8149-c7cac4278fdb',
+        'parameters': {"nthreads": 20},
+        "config": {
+            "instance_type": "c5n.18xlarge",
+            "ebs_size": "3x",
+            "EBS_optimized": True
+        },
+        'custom_pf_fields': {
+            'gvcf': {
+                'file_type': 'gVCF',
+                'description': 'processed output from cgap upstream pipeline'}
+                }
+    },
+    {  # step 10 bamqc
+        'app_name': 'cgap-bamqc',
+        'workflow_uuid': 'd6651132-ab7c-40c0-886f-94f88ef6bdce',
+        'parameters': {},
+        "config": {
+            "instance_type": "c5n.2xlarge",
+            "ebs_size": "2.5x",
+            "EBS_optimized": True,
+            "behavior_on_capacity_limit": "wait_and_retry"
+        }
+    },
+    #  ____   __   ____  ____    __  __
+    # (  _ \ / _\ (  _ \(_  _)  (  )(  )
+    #  ) __//    \ )   /  )(     )(  )(
+    # (__)  \_/\_/(__\_) (__)   (__)(__)
+    # Multi sample analysis
+    {
+        'app_name': 'workflow_gatk-CombineGVCFs',
+        'workflow_uuid': 'c7223a1c-ed48-4c54-a39f-35f05d61e850',
+        'parameters': {},
+        "config": {
+            "instance_type": "c5n.4xlarge",
+            "EBS_optimized": True
+        },
+        'custom_pf_fields': {
+            'combined_gvcf': {
+                'file_type': 'combined gVCF',
+                'description': 'processed output from cgap downstream pipeline'}
+                }
+    },
+    {
+        'app_name': 'workflow_gatk-GenotypeGVCFs-check',
+        'workflow_uuid': '4fbad226-859d-40d4-8192-10c305e819da',
+        'parameters': {},
+        "config": {
+            "instance_type": "c5n.4xlarge",
+            "ebs_size": "1.5x",
+            "EBS_optimized": True
+        },
+        'custom_pf_fields': {
+            'vcf': {
+                'file_type': 'raw VCF',
+                'description': 'processed output from cgap downstream pipeline'}
+                }
+    },
+    {  # VEP
+        'app_name': 'workflow_vep-parallel',
+        'workflow_uuid': '7a9d1047-1966-4563-9f62-e7f1ea7ff0dc',
+        'parameters': {"nthreads": 15},
+        "config": {
+            "instance_type": "c5.9xlarge",
+            "ebs_size": "10x",
+            "EBS_optimized": True
+        },
+        'custom_pf_fields': {
+            'microannot_mti': {
+                'file_type': 'intermediate file',
+                'description': 'Intermediate file'
+                },
+            'annot_mti': {
+                'file_type': 'intermediate file',
+                'description': 'Intermediate file'
+                }
+        }
+    },
+    {  # micro-annotation
+        'app_name': 'workflow_mutanno-micro-annot-check',
+        'workflow_uuid': 'ca3469c6-ac71-4a7d-97ea-477037b05f2f',
+        'parameters': {"nthreads": 70},
+        "config": {
+            "instance_type": "c5n.18xlarge",
+            "ebs_size": "3x",
+            "EBS_optimized": True
+        },
+        'custom_pf_fields': {
+            'annotated_vcf': {
+                'file_type': 'micro-annotated VCF',
+                'description': 'micro-annotated VCF file'
+            }
+        }
+    },
+    #  ____   __   ____  ____    __  __  __
+    # (  _ \ / _\ (  _ \(_  _)  (  )(  )(  )
+    #  ) __//    \ )   /  )(     )(  )(  )(
+    # (__)  \_/\_/(__\_) (__)   (__)(__)(__)
+    {  # step1a rckTar
+        'app_name': 'workflow_granite-rckTar',
+        'workflow_uuid': '64ff003a-b25d-4856-a9fc-ad8702b8c6d4',
+        'parameters': {},
+        "config": {
+            "instance_type": "c5.xlarge",
+            "ebs_size": "2.5x",
+            "EBS_optimized": True
+        },
+        'custom_pf_fields': {
+            'rck_tar': {
+                'file_type': 'tarred read counts (rck)',
+                'description': 'tarred read counts (rck) file'
+            }
+        }
+    },
+    {  # Step2 - filtering
+        'app_name': 'workflow_granite-filtering-check',
+        'workflow_uuid': 'e43171b4-4ee5-4074-8734-727399e3179d',
+        'parameters': {"aftag": "gnomADgenome", "afthr": 0.01},
+        "config": {
+            "instance_type": "t3.medium",
+            "ebs_size": "6x",
+            "EBS_optimized": True
+        },
+        'custom_pf_fields': {
+            'merged_vcf': {
+                'file_type': 'intermediate file',
+                'description': 'Intermediate VCF file'
+            }
+        }
+    },
+    {  # Step3 - novocaller
+        'app_name': 'workflow_granite-novoCaller-rck-check',
+        'workflow_uuid': '55c9ebf7-ef39-4eb0-9685-c090f2e788ae',
+        'parameters': {},
+        "config": {
+            "instance_type": "c5.xlarge",
+            "ebs_size": "1.5x",
+            "EBS_optimized": True
+        },
+        'custom_pf_fields': {
+            'novoCaller_vcf': {
+                'file_type': 'intermediate file',
+                'description': 'Intermediate VCF file'
+            }
+        }
+    },
+    {  # Step4 - compHet
+        'app_name': 'workflow_granite-comHet-check',
+        'workflow_uuid': 'f43c5ac3-d755-4acc-a6ed-7f65b8b4961b',
+        'parameters': {},
+        "config": {
+            "instance_type": "t3.small",
+            "ebs_size": "2.5x",
+            "EBS_optimized": True
+        },
+        'custom_pf_fields': {
+            'comHet_vcf': {
+                'file_type': 'intermediate file',
+                'description': 'Intermediate VCF file'
+            }
+        }
+    },
+    {  # Step5 - full annotation
+        'app_name': 'workflow_mutanno-annot-check',
+        'workflow_uuid': '3b18898d-7be5-4020-95d6-3fa453da70cf',
+        'parameters': {"nthreads": 1},
+        "config": {
+            "instance_type": "c5.large",
+            "ebs_size": "1.2x",
+            "EBS_optimized": True
+        },
+        'custom_pf_fields': {
+            'annotated_vcf': {
+                'file_type': 'full annotated VCF',
+                'description': 'full annotated VCF file'
+            }
+        }
+    },
+    {  # Step 6 = bamsnap
+        'app_name': 'bamsnap',
+        'workflow_uuid': 'a4016214-e4ce-4a34-93a1-c0751bbd1d37',
+        'parameters': {"nproc": 16},
+        "config": {
+            "instance_type": "c5.4xlarge",
+            "ebs_size": 10,
+            "EBS_optimized": True
+        }
+    },
+    {  # VCFQC used in Part III
+        'app_name': 'workflow_granite-qcVCF',
+        'workflow_uuid': '33a85705-b757-49e0-aaef-d786695d6d03',
+        'parameters': {"trio_errors": True,
+                       "het_hom": True,
+                       "ti_tv": True},
+        "config": {
+            "instance_type": "t3.small",
+            "ebs_size": "1.5x",
+            "EBS_optimized": True
+        }
+    },
+    {  # temp
+        'app_name': '',
+        'workflow_uuid': '',
+        'parameters': {},
+        "config": {
+            "instance_type": "",
+            "ebs_size": "",
+            "EBS_optimized": True
+        },
+        'custom_pf_fields': {
+            'temp': {
+                'file_type': 'intermediate file',
+                'description': 'Intermediate alignment file'}
+                }
+    }
+]
+
 
 def step_settings(step_name, my_organism, attribution, overwrite=None):
     """Return a setting dict for given step, and modify variables in
@@ -21,452 +441,17 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
     """
     genome = ""
     genome = mapper.get(my_organism)
-    # int_n_rep = "This is an intermediate file in the Repliseq processing pipeline"
 
-    wf_dict = [
-            {
-                'app_name': 'md5',
-                'workflow_uuid': 'c77a117b-9a58-477e-aaa5-291a109a99f6',
-                "config": {"ebs_size": 10}
-            },
-            {
-                'app_name': 'fastqc',
-                'workflow_uuid': '49e96b51-ed6c-4418-a693-d0e9f79adfa5',
-                "config": {
-                    "ebs_size": 10,
-                    "instance_type": 't3.micro',
-                    'EBS_optimized': True
-                    }
-            },
-            {  # cram to fastq converter
-                'app_name': 'workflow_cram2fastq',
-                'workflow_uuid': '7bbf3487-a1fc-4073-952a-d5771973e875',
-                'parameters': {},
-                "config": {
-                    "instance_type": "c5.4xlarge",
-                    "ebs_size": "30x",
-                    "EBS_optimized": True
-                },
-                'custom_pf_fields': {
-                    'fastq1': {
-                        'genome_assembly': genome,
-                        'file_type': 'reads',
-                        'description': 'Fastq files produced from CRAM files - paired end:1'},
-                    'fastq2': {
-                        'genome_assembly': genome,
-                        'file_type': 'reads',
-                        'description': 'Fastq files produced from CRAM files - paired end:2'}
-                        }
-            },
-            {  # cram to bam converter
-                'app_name': 'workflow_cram2bam-check',
-                'workflow_uuid': '2a086f2b-7be4-4708-9516-1b39639292bf',
-                'parameters': {},
-                "config": {
-                    "instance_type": "c5.2xlarge",
-                    "ebs_size": "4.5x",
-                    "EBS_optimized": True
-                },
-                'custom_pf_fields': {
-                    'converted_bam': {
-                        'genome_assembly': genome,
-                        'file_type': 'alignments',
-                        'description': 'BAM file converted from CRAM file'
-                    }
-                }
-            },
-            # http://patorjk.com/software/taag/#p=display&v=1&f=Graceful&t=QC
-            #   __    ___
-            #  /  \  / __)
-            # (  O )( (__
-            #  \__\) \___)
-            {
-               "app_name": "workflow_qcboard-bam",
-               "parameters": {},
-               "workflow_uuid": "ad8716a3-b6e8-4021-bbc6-b0cefc9c4dd8",
-               "config": {
-                 "instance_type": "t3.medium",
-                 "ebs_size": "1.3x",
-                 "EBS_optimized": True
-               }
-            },
-            #  ____   __   ____  ____    __
-            # (  _ \ / _\ (  _ \(_  _)  (  )
-            #  ) __//    \ )   /  )(     )(
-            # (__)  \_/\_/(__\_) (__)   (__)
-            # step1
-            {
-                'app_name': 'workflow_bwa-mem_no_unzip-check',
-                'workflow_uuid': '50e75343-2e00-471d-a667-4acb083287d8',
-                'parameters': {},
-                "config": {
-                    "instance_type": "c5n.18xlarge",
-                    "ebs_size": "5x",
-                    "EBS_optimized": True,
-                    "behavior_on_capacity_limit": "wait_and_retry"
-                    },
-                'custom_pf_fields': {
-                    'raw_bam': {
-                        'genome_assembly': genome,
-                        'file_type': 'intermediate file',
-                        'description': 'Intermediate alignment file'}
-                        }
-            },
-            # step2
-            {
-                'app_name': 'workflow_add-readgroups-check',
-                'workflow_uuid': 'd554d59b-e709-4c35-a81f-68a0cb3dd38a',
-                'parameters': {},
-                "config": {
-                    "instance_type": "c5.2xlarge",
-                    "ebs_size": "2.2x",
-                    "EBS_optimized": True,
-                    "behavior_on_capacity_limit": "wait_and_retry"
-                    },
-                'custom_pf_fields': {
-                    'bam_w_readgroups': {
-                        'genome_assembly': genome,
-                        'file_type': 'intermediate file',
-                        'description': 'Intermediate alignment file'}
-                        }
-            },
-            # step3
-            {
-                'app_name': 'workflow_merge-bam-check',
-                'workflow_uuid': '4853a03a-8c0c-4624-a45d-c5206a72907b',
-                'parameters': {},
-                "config": {
-                    "instance_type": "c5.2xlarge",
-                    "ebs_size": "2.2x",
-                    "EBS_optimized": True,
-                    "behavior_on_capacity_limit": "wait_and_retry"
-                },
-                'custom_pf_fields': {
-                    'merged_bam': {
-                        'genome_assembly': genome,
-                        'file_type': 'intermediate file',
-                        'description': 'Intermediate alignment file'}
-                        }
-            },
-            {  # step 4
-                'app_name': 'workflow_picard-MarkDuplicates-check',
-                'workflow_uuid': 'beb2b340-94ee-4afe-b4e3-66caaf063397',
-                'parameters': {},
-                "config": {
-                    "instance_type": "c5n.18xlarge",
-                    "ebs_size": "3x",
-                    "EBS_optimized": True,
-                    "behavior_on_capacity_limit": "wait_and_retry"
-                },
-                'custom_pf_fields': {
-                    'dupmarked_bam': {
-                        'genome_assembly': genome,
-                        'file_type': 'intermediate file',
-                        'description': 'Intermediate alignment file'}
-                        }
-            },
-            {  # step 5
-                'app_name': 'workflow_sort-bam-check',
-                'workflow_uuid': '560f5194-cd3a-4799-9b1a-6a2d2c371c89',
-                'parameters': {},
-                "config": {
-                    "instance_type": "m5a.2xlarge",
-                    "ebs_size": "3.2x",
-                    "EBS_optimized": True,
-                    "behavior_on_capacity_limit": "wait_and_retry"
-                },
-                'custom_pf_fields': {
-                    'sorted_bam': {
-                        'genome_assembly': genome,
-                        'file_type': 'intermediate file',
-                        'description': 'Intermediate alignment file'}
-                        }
-            },
-            {  # step 6
-                'app_name': 'workflow_gatk-BaseRecalibrator',
-                'workflow_uuid': '455b3056-64ca-4a9b-b546-294b01c9ca92',
-                'parameters': {},
-                "config": {
-                    "instance_type": "t3.small",
-                    "ebs_size": "2x",
-                    "EBS_optimized": True,
-                    "behavior_on_capacity_limit": "wait_and_retry"
-                },
-                'custom_pf_fields': {
-                    'recalibration_report': {
-                        'genome_assembly': genome,
-                        'file_type': 'intermediate file',
-                        'description': 'Intermediate alignment file'}
-                        }
-            },
-            {  # step 7
-                'app_name': 'workflow_gatk-ApplyBQSR-check',
-                'workflow_uuid': '6c9c6f49-f954-4e76-8dfb-d385cddcebd6',
-                'parameters': {},
-                "config": {
-                    "instance_type": "t3.micro",
-                    "ebs_size": "2.5x",
-                    "EBS_optimized": True,
-                    "behavior_on_capacity_limit": "wait_and_retry"
-                },
-                'custom_pf_fields': {
-                    'recalibrated_bam': {
-                        'genome_assembly': genome,
-                        'file_type': 'alignments',
-                        'description': 'processed output from cgap upstream pipeline'}
-                        }
-            },
-            # part 1 - step 8   (only run for samples that will go to part3)
-            {  # mpileupCounts
-                'app_name': 'workflow_granite-mpileupCounts',
-                'workflow_uuid': 'c6dac0af-631d-402f-a1c1-282e091f1b3e',
-                'parameters': {"nthreads": 15},
-                "config": {
-                    "instance_type": "c5.4xlarge",
-                    "ebs_size": 120,
-                    "EBS_optimized": True
-                },
-                'custom_pf_fields': {
-                    'rck': {
-                        'genome_assembly': genome,
-                        'file_type': 'read counts (rck)',
-                        'description': 'read counts (rck) file'
-                    }
-                }
-            },
-            # step 9
-            {
-                'app_name': 'workflow_gatk-HaplotypeCaller',
-                'workflow_uuid': '7fd67e19-3425-45f8-8149-c7cac4278fdb',
-                'parameters': {"nthreads": 20},
-                "config": {
-                    "instance_type": "c5n.18xlarge",
-                    "ebs_size": "3x",
-                    "EBS_optimized": True
-                },
-                'custom_pf_fields': {
-                    'gvcf': {
-                        'genome_assembly': genome,
-                        'file_type': 'gVCF',
-                        'description': 'processed output from cgap upstream pipeline'}
-                        }
-            },
-            {  # step 10 bamqc
-                'app_name': 'cgap-bamqc',
-                'workflow_uuid': 'd6651132-ab7c-40c0-886f-94f88ef6bdce',
-                'parameters': {},
-                "config": {
-                    "instance_type": "c5n.2xlarge",
-                    "ebs_size": "2.5x",
-                    "EBS_optimized": True,
-                    "behavior_on_capacity_limit": "wait_and_retry"
-                }
-            },
-            #  ____   __   ____  ____    __  __
-            # (  _ \ / _\ (  _ \(_  _)  (  )(  )
-            #  ) __//    \ )   /  )(     )(  )(
-            # (__)  \_/\_/(__\_) (__)   (__)(__)
-            # Multi sample analysis
-            {
-                'app_name': 'workflow_gatk-CombineGVCFs',
-                'workflow_uuid': 'c7223a1c-ed48-4c54-a39f-35f05d61e850',
-                'parameters': {},
-                "config": {
-                    "instance_type": "c5n.4xlarge",
-                    "EBS_optimized": True
-                },
-                'custom_pf_fields': {
-                    'combined_gvcf': {
-                        'genome_assembly': genome,
-                        'file_type': 'combined gVCF',
-                        'description': 'processed output from cgap downstream pipeline'}
-                        }
-            },
-            {
-                'app_name': 'workflow_gatk-GenotypeGVCFs-check',
-                'workflow_uuid': '4fbad226-859d-40d4-8192-10c305e819da',
-                'parameters': {},
-                "config": {
-                    "instance_type": "c5n.4xlarge",
-                    "ebs_size": "1.5x",
-                    "EBS_optimized": True
-                },
-                'custom_pf_fields': {
-                    'vcf': {
-                        'genome_assembly': genome,
-                        'file_type': 'raw VCF',
-                        'description': 'processed output from cgap downstream pipeline'}
-                        }
-            },
-            {  # VEP
-                'app_name': 'workflow_vep-parallel',
-                'workflow_uuid': '7a9d1047-1966-4563-9f62-e7f1ea7ff0dc',
-                'parameters': {"nthreads": 15},
-                "config": {
-                    "instance_type": "c5.9xlarge",
-                    "ebs_size": "10x",
-                    "EBS_optimized": True
-                },
-                'custom_pf_fields': {
-                    'microannot_mti': {
-                        'genome_assembly': genome,
-                        'file_type': 'intermediate file',
-                        'description': 'Intermediate file'
-                        },
-                    'annot_mti': {
-                        'genome_assembly': genome,
-                        'file_type': 'intermediate file',
-                        'description': 'Intermediate file'
-                        }
-                }
-            },
-            {  # micro-annotation
-                'app_name': 'workflow_mutanno-micro-annot-check',
-                'workflow_uuid': 'ca3469c6-ac71-4a7d-97ea-477037b05f2f',
-                'parameters': {"nthreads": 70},
-                "config": {
-                    "instance_type": "c5n.18xlarge",
-                    "ebs_size": "3x",
-                    "EBS_optimized": True
-                },
-                'custom_pf_fields': {
-                    'annotated_vcf': {
-                        'genome_assembly': genome,
-                        'file_type': 'micro-annotated VCF',
-                        'description': 'micro-annotated VCF file'
-                    }
-                }
-            },
-            #  ____   __   ____  ____    __  __  __
-            # (  _ \ / _\ (  _ \(_  _)  (  )(  )(  )
-            #  ) __//    \ )   /  )(     )(  )(  )(
-            # (__)  \_/\_/(__\_) (__)   (__)(__)(__)
-            {  # step1a rckTar
-                'app_name': 'workflow_granite-rckTar',
-                'workflow_uuid': '64ff003a-b25d-4856-a9fc-ad8702b8c6d4',
-                'parameters': {},
-                "config": {
-                    "instance_type": "c5.xlarge",
-                    "ebs_size": "2.5x",
-                    "EBS_optimized": True
-                },
-                'custom_pf_fields': {
-                    'rck_tar': {
-                        'genome_assembly': genome,
-                        'file_type': 'tarred read counts (rck)',
-                        'description': 'tarred read counts (rck) file'
-                    }
-                }
-            },
-            {  # Step2 - filtering
-                'app_name': 'workflow_granite-filtering-check',
-                'workflow_uuid': 'e43171b4-4ee5-4074-8734-727399e3179d',
-                'parameters': {"aftag": "gnomADgenome", "afthr": 0.01},
-                "config": {
-                    "instance_type": "t3.medium",
-                    "ebs_size": "6x",
-                    "EBS_optimized": True
-                },
-                'custom_pf_fields': {
-                    'merged_vcf': {
-                        'genome_assembly': genome,
-                        'file_type': 'intermediate file',
-                        'description': 'Intermediate VCF file'
-                    }
-                }
-            },
-            {  # Step3 - novocaller
-                'app_name': 'workflow_granite-novoCaller-rck-check',
-                'workflow_uuid': '55c9ebf7-ef39-4eb0-9685-c090f2e788ae',
-                'parameters': {},
-                "config": {
-                    "instance_type": "c5.xlarge",
-                    "ebs_size": "1.5x",
-                    "EBS_optimized": True
-                },
-                'custom_pf_fields': {
-                    'novoCaller_vcf': {
-                        'genome_assembly': genome,
-                        'file_type': 'intermediate file',
-                        'description': 'Intermediate VCF file'
-                    }
-                }
-            },
-            {  # Step4 - compHet
-                'app_name': 'workflow_granite-comHet-check',
-                'workflow_uuid': 'f43c5ac3-d755-4acc-a6ed-7f65b8b4961b',
-                'parameters': {},
-                "config": {
-                    "instance_type": "t3.small",
-                    "ebs_size": "2.5x",
-                    "EBS_optimized": True
-                },
-                'custom_pf_fields': {
-                    'comHet_vcf': {
-                        'genome_assembly': genome,
-                        'file_type': 'intermediate file',
-                        'description': 'Intermediate VCF file'
-                    }
-                }
-            },
-            {  # Step5 - full annotation
-                'app_name': 'workflow_mutanno-annot-check',
-                'workflow_uuid': '3b18898d-7be5-4020-95d6-3fa453da70cf',
-                'parameters': {"nthreads": 1},
-                "config": {
-                    "instance_type": "c5.large",
-                    "ebs_size": "1.2x",
-                    "EBS_optimized": True
-                },
-                'custom_pf_fields': {
-                    'annotated_vcf': {
-                        'genome_assembly': genome,
-                        'file_type': 'full annotated VCF',
-                        'description': 'full annotated VCF file'
-                    }
-                }
-            },
-            {  # Step 6 = bamsnap
-                'app_name': 'bamsnap',
-                'workflow_uuid': 'a4016214-e4ce-4a34-93a1-c0751bbd1d37',
-                'parameters': {"nproc": 16},
-                "config": {
-                    "instance_type": "c5.4xlarge",
-                    "ebs_size": 10,
-                    "EBS_optimized": True
-                }
-            },
-            {  # VCFQC used in Part III
-                'app_name': 'workflow_granite-qcVCF',
-                'workflow_uuid': '33a85705-b757-49e0-aaef-d786695d6d03',
-                'parameters': {"trio_errors": True,
-                               "het_hom": True,
-                               "ti_tv": True},
-                "config": {
-                    "instance_type": "t3.small",
-                    "ebs_size": "1.5x",
-                    "EBS_optimized": True
-                }
-            },
-            {  # temp
-                'app_name': '',
-                'workflow_uuid': '',
-                'parameters': {},
-                "config": {
-                    "instance_type": "",
-                    "ebs_size": "",
-                    "EBS_optimized": True
-                },
-                'custom_pf_fields': {
-                    'temp': {
-                        'genome_assembly': genome,
-                        'file_type': 'intermediate file',
-                        'description': 'Intermediate alignment file'}
-                        }
-            }
-            ]
+    templates = [i for i in wf_dict if i['app_name'] == step_name][0]
+    # every app name should exist only once in wf_dict
+    assert len(templates) == 1
+    template = templates[0]
 
-    template = [i for i in wf_dict if i['app_name'] == step_name][0]
+    # add genomes to output files
+    if template.get('custom_pf_fields'):
+        for an_output_file in template['custom_pf_fields']:
+            template['custom_pf_fields'][an_output_file]['genome_assembly'] = genome
+
     update_config = {
         "spot_instance": True,
         "log_bucket": "tibanna-output",

--- a/chalicelib/checks/helpers/wfrset_cgap_utils.py
+++ b/chalicelib/checks/helpers/wfrset_cgap_utils.py
@@ -298,6 +298,23 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
                         'description': 'processed output from cgap downstream pipeline'}
                         }
             },
+            {  # micro-annotation
+                'app_name': 'workflow_mutanno-micro-annot-check',
+                'workflow_uuid': '087325b4-f098-4a43-a190-81a878039de2',
+                'parameters': {"nthreads": 70},
+                "config": {
+                    "instance_type": "c5n.18xlarge",
+                    "ebs_size": "3x",
+                    "EBS_optimized": True
+                },
+                'custom_pf_fields': {
+                    'annotated_vcf': {
+                        'genome_assembly': genome,
+                        'file_type': 'micro-annotated VCF',
+                        'description': 'micro-annotated VCF file'
+                    }
+                }
+            },
             #  ____   __   ____  ____    __  __  __
             # (  _ \ / _\ (  _ \(_  _)  (  )(  )(  )
             #  ) __//    \ )   /  )(     )(  )(  )(
@@ -316,23 +333,6 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
                         'genome_assembly': genome,
                         'file_type': 'tarred read counts (rck)',
                         'description': 'tarred read counts (rck) file'
-                    }
-                }
-            },
-            {  # Step1b micro-annotation
-                'app_name': 'workflow_mutanno-micro-annot-check',
-                'workflow_uuid': '087325b4-f098-4a43-a190-81a878039de2',
-                'parameters': {"nthreads": 70},
-                "config": {
-                    "instance_type": "c5n.18xlarge",
-                    "ebs_size": "3x",
-                    "EBS_optimized": True
-                },
-                'custom_pf_fields': {
-                    'annotated_vcf': {
-                        'genome_assembly': genome,
-                        'file_type': 'micro-annotated VCF',
-                        'description': 'micro-annotated VCF file'
                     }
                 }
             },

--- a/chalicelib/checks/helpers/wfrset_cgap_utils.py
+++ b/chalicelib/checks/helpers/wfrset_cgap_utils.py
@@ -219,7 +219,7 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
             # part 1 - step 8   (only run for samples that will go to part3)
             {  # mpileupCounts
                 'app_name': 'workflow_granite-mpileupCounts',
-                'workflow_uuid': '6e89bc5d-b4a0-4954-9c3f-361477d5f537',
+                'workflow_uuid': 'c6dac0af-631d-402f-a1c1-282e091f1b3e',
                 'parameters': {"nthreads": 15},
                 "config": {
                     "instance_type": "c5.4xlarge",
@@ -322,7 +322,7 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
             },
             {  # micro-annotation
                 'app_name': 'workflow_mutanno-micro-annot-check',
-                'workflow_uuid': '087325b4-f098-4a43-a190-81a878039de2',
+                'workflow_uuid': 'ca3469c6-ac71-4a7d-97ea-477037b05f2f',
                 'parameters': {"nthreads": 70},
                 "config": {
                     "instance_type": "c5n.18xlarge",
@@ -343,7 +343,7 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
             # (__)  \_/\_/(__\_) (__)   (__)(__)(__)
             {  # step1a rckTar
                 'app_name': 'workflow_granite-rckTar',
-                'workflow_uuid': '778149e7-98d7-4362-83a4-9e80af1da101',
+                'workflow_uuid': '64ff003a-b25d-4856-a9fc-ad8702b8c6d4',
                 'parameters': {},
                 "config": {
                     "instance_type": "c5.xlarge",
@@ -360,7 +360,7 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
             },
             {  # Step2 - filtering
                 'app_name': 'workflow_granite-filtering-check',
-                'workflow_uuid': 'cb85683c-54a6-44e8-820c-1800aec9fdcd',
+                'workflow_uuid': 'e43171b4-4ee5-4074-8734-727399e3179d',
                 'parameters': {"aftag": "gnomADgenome", "afthr": 0.01},
                 "config": {
                     "instance_type": "t3.medium",
@@ -377,7 +377,7 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
             },
             {  # Step3 - novocaller
                 'app_name': 'workflow_granite-novoCaller-rck-check',
-                'workflow_uuid': 'f38b91fb-7e0c-44e0-a871-a91a58227b34',
+                'workflow_uuid': '55c9ebf7-ef39-4eb0-9685-c090f2e788ae',
                 'parameters': {},
                 "config": {
                     "instance_type": "c5.xlarge",
@@ -394,7 +394,7 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
             },
             {  # Step4 - compHet
                 'app_name': 'workflow_granite-comHet-check',
-                'workflow_uuid': '9e43a0ef-be16-43f1-a789-b76261ee95a3',
+                'workflow_uuid': 'f43c5ac3-d755-4acc-a6ed-7f65b8b4961b',
                 'parameters': {},
                 "config": {
                     "instance_type": "t3.small",
@@ -411,7 +411,7 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
             },
             {  # Step5 - full annotation
                 'app_name': 'workflow_mutanno-annot-check',
-                'workflow_uuid': '26769afe-3d0f-4494-8a67-9acc8de71b73',
+                'workflow_uuid': '3b18898d-7be5-4020-95d6-3fa453da70cf',
                 'parameters': {"nthreads": 1},
                 "config": {
                     "instance_type": "c5.large",

--- a/chalicelib/checks/helpers/wfrset_cgap_utils.py
+++ b/chalicelib/checks/helpers/wfrset_cgap_utils.py
@@ -298,6 +298,28 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
                         'description': 'processed output from cgap downstream pipeline'}
                         }
             },
+            {  # VEP
+                'app_name': 'workflow_vep-parallel',
+                'workflow_uuid': '7a9d1047-1966-4563-9f62-e7f1ea7ff0dc',
+                'parameters': {"nthreads": 15},
+                "config": {
+                    "instance_type": "c5.9xlarge",
+                    "ebs_size": "10x",
+                    "EBS_optimized": True
+                },
+                'custom_pf_fields': {
+                    'microannot_mti': {
+                        'genome_assembly': genome,
+                        'file_type': 'intermediate file',
+                        'description': 'Intermediate file'
+                        },
+                    'annot_mti': {
+                        'genome_assembly': genome,
+                        'file_type': 'intermediate file',
+                        'description': 'Intermediate file'
+                        }
+                }
+            },
             {  # micro-annotation
                 'app_name': 'workflow_mutanno-micro-annot-check',
                 'workflow_uuid': '087325b4-f098-4a43-a190-81a878039de2',

--- a/chalicelib/checks/wfr_cgap_checks.py
+++ b/chalicelib/checks/wfr_cgap_checks.py
@@ -636,7 +636,7 @@ def cgapS2_status(connection, **kwargs):
     analysis_type_filter = "".join(["&analysis_type=" + i for i in accepted_analysis_types])
     version_filter = "".join(["&completed_processes!=" + i for i in cgap_partII_version])
     file_filter = '&samples.processed_files.uuid!=No value'
-    q = query_base + version_filter + analysis_type_filter  # + file_filter
+    q = query_base + version_filter + analysis_type_filter + file_filter
     res = ff_utils.search_metadata(q, my_auth)
     # check if anything in scope
     if not res:

--- a/chalicelib/checks/wfr_cgap_checks.py
+++ b/chalicelib/checks/wfr_cgap_checks.py
@@ -10,9 +10,9 @@ from .helpers import cgap_utils, wfrset_cgap_utils
 lambda_limit = cgap_utils.lambda_limit
 
 # list of acceptible version
-cgap_partI_version = ['WGS_partI_V11', 'WGS_partI_V12', 'WGS_partI_V13', 'WGS_partI_V15', 'WGS_partI_V16']
-cgap_partII_version = ['WGS_partII_V11', 'WGS_partII_V13', 'WGS_partII_V15', 'WGS_partII_V16']
-cgap_partIII_version = ['WGS_partIII_V15', 'WGS_partIII_V16']
+cgap_partI_version = ['WGS_partI_V11', 'WGS_partI_V12', 'WGS_partI_V13', 'WGS_partI_V15', 'WGS_partI_V16', 'WGS_partI_V17']
+cgap_partII_version = ['WGS_partII_V11', 'WGS_partII_V13', 'WGS_partII_V15', 'WGS_partII_V16', 'WGS_partII_V17']
+cgap_partIII_version = ['WGS_partIII_V15', 'WGS_partIII_V16', 'WGS_partIII_V17']
 
 
 @check_function(file_type='File', start_date=None)
@@ -774,6 +774,15 @@ def cgapS2_status(connection, **kwargs):
             keep, step2_status, step2_output = cgap_utils.stepper(library, keep,
                                                                   'step2', s2_tag, step1_output,
                                                                   s2_input_files,  step2_name, 'vcf')
+
+        if step2_status != 'complete':
+            step3_status = ""
+        else:
+            # run step3 micro annotation
+            s3_input_files = {'input_vcf': step2_output,
+                              'mti': "GAPFIFJM2A8Z",
+                                                                                             'step3', s3_tag, step2_output,
+                                                                                             s3_input_files,  step3_name, 'annotated_vcf')
 
         if step2_status != 'complete':
             step3_status = ""

--- a/chalicelib/checks/wfr_cgap_checks.py
+++ b/chalicelib/checks/wfr_cgap_checks.py
@@ -314,10 +314,10 @@ def cgap_status(connection, **kwargs):
     # collect all wf for wf version check
     all_system_wfs = ff_utils.search_metadata('/search/?type=Workflow&status=released', my_auth)
     wf_errs = cgap_utils.check_latest_workflow_version(all_system_wfs)
-    # if wf_errs:
-    #     check.summary = 'Error, problem with latest workflow versions'
-    #     check.brief_output.extend(wf_errs)
-    #     return check
+    if wf_errs:
+        check.summary = 'Error, problem with latest workflow versions'
+        check.brief_output.extend(wf_errs)
+        return check
     cnt = 0
     for a_case in all_cases:
         cnt += 1
@@ -799,7 +799,7 @@ def cgapS2_status(connection, **kwargs):
         if step3_status != 'complete':
             step4_status = ""
         else:
-            # run step3 micro annotation
+            # run step4 micro annotation
             # VEP has 2 outputs, unpack them
             step3_output_micro = step3_outputs[0]
             step3_output_full = step3_outputs[1]
@@ -829,7 +829,7 @@ def cgapS2_status(connection, **kwargs):
                                           "ti_tv": True}}
             s5_tag = an_msa['@id'] + '_Part3step5'
             keep, step3c_status, step3c_output = cgap_utils.stepper(library, keep,
-                                                                    'step3c', s5_tag, step4_output,
+                                                                    'step5', s5_tag, step4_output,
                                                                     s5_input_files,  step5_name, '',
                                                                     additional_input=update_pars, no_output=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.1.3"
+version = "1.1.4"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Updates for V17 to Part II and Part III. 
A new step VEP is added to Part II. has 2 output files, one is used in Part II (micro annotation), and the other one is used in Part III (full annotation). To be able to use the output file meant for Part III, we are adding it to the processed_files field of sample processing. I assumed that there were no changes to config and parameters of existing workflows, please let me know if there were any updates. Only updated micro annotation and full annotation input files to include files from VEP.

To Do
-We need the file type and file description for VEP outputs ( can be added on wfrset_cgap_utils.py line 285-290, currently set to intermediate file)
-There are new workflows for RckTar and Mpileup, however the example V17 full vcf (GAPFIUFA7WNF) was not connected to these steps, again, I assume there were no changes affecting foursight.