### PR TITLE
modify badge check for single bio rep

### DIFF
--- a/chalicelib/checks/badge_checks.py
+++ b/chalicelib/checks/badge_checks.py
@@ -363,9 +363,8 @@ def repsets_have_bio_reps(connection, **kwargs):
 
             # check if single biological replicate
             if len(rep_dict.keys()) == 1:
-                many_replicates = '/static-sections/85520ecd-8df0-4d29-bd78-d8efa1f12ecf/'
-                # this header labels an ExpSet with many replicates, but only one present in the database (typically imaging datasets)
-                if many_replicates in result.get('static_headers', []):  # skip false positive
+                # this tag labels an ExpSet with many replicates, but only one present in the database (typically imaging datasets)
+                if 'many_replicates' in result.get('tags', []):  # skip false positive
                     continue
                 audits[audit_key]['single_biorep'].append(result['@id'])
                 exp_audits.append('Replicate set contains only a single biological replicate')

--- a/chalicelib/checks/badge_checks.py
+++ b/chalicelib/checks/badge_checks.py
@@ -361,7 +361,12 @@ def repsets_have_bio_reps(connection, **kwargs):
             else:
                 audit_key = RELEASED_KEY
 
+            # check if single biological replicate
             if len(rep_dict.keys()) == 1:
+                many_replicates = '/static-sections/85520ecd-8df0-4d29-bd78-d8efa1f12ecf/'
+                # this header labels an ExpSet with many replicates, but only one present in the database (typically imaging datasets)
+                if many_replicates in result.get('static_headers', []):  # skip false positive
+                    continue
                 audits[audit_key]['single_biorep'].append(result['@id'])
                 exp_audits.append('Replicate set contains only a single biological replicate')
             # check if bio rep numbers not in sequence

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.4.15"
+version = "1.4.16"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
This check adds a badge to ExpSets with a single biological replicate. Added an exception to account for false positives.

An ExpSet might have many replicates, but only one present in the database. This happens especially with imaging datasets, where only one replicate with raw data is show as an example, but processed results are derived from many replicates.
Such ExpSets are labeled with a specific [static header](https://data.4dnucleome.org/static-sections/85520ecd-8df0-4d29-bd78-d8efa1f12ecf/). ExpSets with this header to not receive the 'replicate-numbers' badge.