### PR TITLE
Patch qc summary from QualityMetricQclist instead of QualityMetricRnaseq

### DIFF
--- a/chalicelib/checks/helpers/qc_utils.py
+++ b/chalicelib/checks/helpers/qc_utils.py
@@ -6,10 +6,10 @@ def calculate_qc_metric_rnaseq(file_uuid, key):
     with quality_metric summary'''
     res = ff_utils.get_metadata(file_uuid, key=key)
     qc_uuid = res['quality_metric']['uuid']
-    qc_list = ff_utils.get_metadata(qc_uuid, key=key)
+    quality_metric = ff_utils.get_metadata(qc_uuid, key=key)
     qc_summary = []
 
-    for qcs_item in qc_list.get('quality_metric_summary', []):
+    for qcs_item in quality_metric.get('quality_metric_summary', []):
         qc_summary.append(qcs_item)
     res = ff_utils.patch_metadata({'quality_metric_summary': qc_summary}, file_uuid, key=key)
     return res

--- a/chalicelib/checks/helpers/qc_utils.py
+++ b/chalicelib/checks/helpers/qc_utils.py
@@ -6,28 +6,11 @@ def calculate_qc_metric_rnaseq(file_uuid, key):
     with quality_metric summary'''
     res = ff_utils.get_metadata(file_uuid, key=key)
     qc_uuid = res['quality_metric']['uuid']
-    quality_metric = ff_utils.get_metadata(qc_uuid, key=key)
+    qc_list = ff_utils.get_metadata(qc_uuid, key=key)
     qc_summary = []
 
-    if 'star_log_qc' in quality_metric:
-        uniquely_mapped = quality_metric['star_log_qc']['Uniquely mapped reads number']
-        multi_mapped = quality_metric['star_log_qc']['Number of reads mapped to multiple loci']
-        total_mapped = int(uniquely_mapped) + int(multi_mapped)
-        qc_summary.append({"title": "Total mapped reads (genome)",
-                           "value": str(total_mapped),
-                           "numberType": "integer"})
-        qc_summary.append({"title": "Total uniquely mapped reads (genome)",
-                           "value": str(uniquely_mapped),
-                           "numberType": "integer"})
-    else:
-        if 'gene_type_count' not in quality_metric:
-            raise Exception("Quality Metric Object does not have the correct fields")
-        qc_summary.append({"title": "Reads mapped to protein-coding genes",
-                           "value": str(quality_metric['gene_type_count']['protein_coding']),
-                           "numberType": "integer"})
-        qc_summary.append({"title": "Reads mapped to rRNA",
-                           "value": str(quality_metric['gene_type_count']['rRNA']),
-                           "numberType": "integer"})
+    for qcs_item in qc_list.get('quality_metric_summary', []):
+        qc_summary.append(qcs_item)
     res = ff_utils.patch_metadata({'quality_metric_summary': qc_summary}, file_uuid, key=key)
     return res
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.4.18"
+version = "1.4.19"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.4.17"
+version = "1.4.18"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
The quality_metric of Processed files from RNA-seq pipeline can be either QualityMetricQclist or QualityMetricRnaseq. This check patches the quality_metric_summary of the Processed File by looking at quality_metric.quality_metric_summary (common to both QualityMetric types).