### PR TITLE
Fix search url check

### DIFF
--- a/chalicelib/checks/audit_checks.py
+++ b/chalicelib/checks/audit_checks.py
@@ -482,7 +482,7 @@ def check_search_urls(connection, **kwargs):
         urls = re.findall(r'[\(\[=]["]*(?:[^\s\)\]]+(?:4dnucleome|elasticbeanstalk)[^\s\)\]]+|/)((?:browse|search)/\?[^\s\)\]]+)[\)\]"]', body)
         if urls:
             for url in urls:
-                # url = url.replace('&amp;', '&')  # replace HTML &amp;
+                url = url.replace('&amp;', '&')  # replace HTML &amp;
                 url = re.sub(r'&limit=[^&]*|limit=[^&]*&?', '', url)  # remove limit if present
                 q_results = ff_utils.search_metadata(url + '&limit=1&field=@id', key=connection.ff_keys)
                 if len(q_results) == 0:

--- a/chalicelib/checks/audit_checks.py
+++ b/chalicelib/checks/audit_checks.py
@@ -421,7 +421,7 @@ def check_help_page_urls(connection, **kwargs):
                 # remove these from body so body can be checked for other types of links
                 body = body[:body.index(link)] + body[body.index(link)+len(link):]
         # looks for links starting with http (full) or / (relative) inside parentheses or brackets
-        urls += re.findall(r'[\(|\[|=]["]*(http[^\s\)\]"]+|/[^\s\)\]"]+)[\)|\]|"]', body)
+        urls += re.findall(r'[\(\[=]["]*(http[^\s\)\]"]+|/[^\s\)\]"]+)[\)\]"]', body)
         for url in urls:
             if url.startswith('mailto'):
                 continue
@@ -479,9 +479,10 @@ def check_search_urls(connection, **kwargs):
     for result in results:
         body = result.get('body', '')
         # search links for search or browse pages, either explicit or relative
-        urls = re.findall(r'[\(|\[|=]["]*(?:[^\s\)\]]+(?:4dnucleome|elasticbeanstalk)[^\s\)\]]+|/)((?:browse|search)/\?[^\s\)\]]+)[\)|\]|"]', body)
+        urls = re.findall(r'[\(\[=]["]*(?:[^\s\)\]]+(?:4dnucleome|elasticbeanstalk)[^\s\)\]]+|/)((?:browse|search)/\?[^\s\)\]]+)[\)\]"]', body)
         if urls:
             for url in urls:
+                # url = url.replace('&amp;', '&')  # replace HTML &amp;
                 url = re.sub(r'&limit=[^&]*|limit=[^&]*&?', '', url)  # remove limit if present
                 q_results = ff_utils.search_metadata(url + '&limit=1&field=@id', key=connection.ff_keys)
                 if len(q_results) == 0:

--- a/chalicelib/checks/audit_checks.py
+++ b/chalicelib/checks/audit_checks.py
@@ -479,7 +479,7 @@ def check_search_urls(connection, **kwargs):
     for result in results:
         body = result.get('body', '')
         # search links for search or browse pages, either explicit or relative
-        urls = re.findall(r'[\(\[=]["]*(?:[^\s\)\]]+(?:4dnucleome|elasticbeanstalk)[^\s\)\]]+|/)((?:browse|search)/\?[^\s\)\]]+)[\)\]"]', body)
+        urls = re.findall(r'[\(\[=]["]*(?:[^\s\)\]"]+(?:4dnucleome|elasticbeanstalk)[^\s\)\]"]+|/)((?:browse|search)/\?[^\s\)\]"]+)[\)\]"]', body)
         if urls:
             for url in urls:
                 url = url.replace('&amp;', '&')  # replace HTML &amp;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.4.28"
+version = "1.4.29"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Static sections that are encoded in HTML get an automatic replacement of `&` with `&amp;`. The foursight check check_search_urls that tests browse/search queries was previously able to resolve those and find the correct result. Recently, it started returning empty results, due to the fact that `&amp;` is not interpreted correctly. It is unclear what is the exact reason why this appeared only now.
Regardless of that, the proposed change in the foursight check is to replace `&amp;` with `&`, so that it can be tested correctly.