### PR TITLE
updated wfr attribution adder function

### DIFF
--- a/chalicelib/checks/helpers/wfr_utils.py
+++ b/chalicelib/checks/helpers/wfr_utils.py
@@ -501,26 +501,22 @@ def get_wfr_out(emb_file, wfr_name, key=None, all_wfrs=None, versions=None, md_q
 def get_attribution(file_json):
     """give file response in embedded frame and extract attribution info"""
     attributions = {
-        'lab': file_json['lab']['@id'],
-        'award': file_json['award']['@id']
+        'lab': '/labs/4dn-dcic-lab/',
+        'award': '/awards/2U01CA200059-06/'
     }
+    assert file_json.get('lab').get('@id')  # assume this is not really necessary
+    file_lab = file_json['lab']['@id']
+    appendLab = True
+    if file_lab == '/labs/4dn-dcic-lab/':
+        appendLab = False
     cont_labs = []
     if file_json.get('contributing_labs'):
         cont_labs = [i['@id'] for i in file_json['contributing_labs']]
-    appendFDN = True
-    if attributions['lab'] == '/labs/4dn-dcic-lab/':
-        appendFDN = False
+    if appendLab:
+        cont_labs.append(file_lab)
+    cont_labs = list(set(cont_labs))
     if cont_labs:
-        if appendFDN:
-            cont_labs.append('/labs/4dn-dcic-lab/')
-            cont_labs = list(set(cont_labs))
         attributions['contributing_labs'] = cont_labs
-    else:
-        if appendFDN:
-            cont_labs = ['/labs/4dn-dcic-lab/']
-            attributions['contributing_labs'] = cont_labs
-        else:
-            pass
     return attributions
 
 

--- a/chalicelib/checks/helpers/wfr_utils.py
+++ b/chalicelib/checks/helpers/wfr_utils.py
@@ -500,21 +500,18 @@ def get_wfr_out(emb_file, wfr_name, key=None, all_wfrs=None, versions=None, md_q
 
 def get_attribution(file_json):
     """give file response in embedded frame and extract attribution info"""
+    dciclab = '/labs/4dn-dcic-lab/'
     attributions = {
-        'lab': '/labs/4dn-dcic-lab/',
+        'lab': dciclab,
         'award': '/awards/2U01CA200059-06/'
     }
     assert file_json.get('lab').get('@id')  # assume this is not really necessary
     file_lab = file_json['lab']['@id']
-    appendLab = True
-    if file_lab == '/labs/4dn-dcic-lab/':
-        appendLab = False
     cont_labs = []
     if file_json.get('contributing_labs'):
         cont_labs = [i['@id'] for i in file_json['contributing_labs']]
-    if appendLab:
+    if file_lab != dciclab and file_lab not in cont_labs:
         cont_labs.append(file_lab)
-    cont_labs = list(set(cont_labs))
     if cont_labs:
         attributions['contributing_labs'] = cont_labs
     return attributions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.4.37"
+version = "1.4.38"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
modified add_attribution function so that all processed_files, workflow_runs and QCs will be attributed to 4DN-DCIC lab and the submitting lab of the raw files will be added as a contributing lab and otherwise contributing lab will be maintained - in subsequent steps

Note: I don't believe I changed the basic premise that the general assumption is that a pipeline will start off with 'raw' files that have been submitted by an 'experimental' lab.  That lab will become a contributing lab for resulting processed files and then when those processed files metadata is added the lab and contributing lab are essentially inherited from the previous item in the pipeline but if this assumption is incorrect please correct my misunderstanding.