### PR TITLE
update higlass registration check/action to utilize open_data_url if present

### DIFF
--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -1672,6 +1672,7 @@ def files_not_registered_with_higlass(connection, **kwargs):
             "uuid",
             "extra_files",
             "upload_key",
+            "open_data_url"
         ):
             search_query += "&field=" + new_field
 
@@ -1702,7 +1703,8 @@ def files_not_registered_with_higlass(connection, **kwargs):
                 'uuid': procfile['uuid'],
                 'file_format': procfile['file_format'].get('file_format'),
                 'higlass_uid': procfile.get('higlass_uid'),
-                'genome_assembly': procfile['genome_assembly']
+                'genome_assembly': procfile['genome_assembly'],
+                'open_data_url': procfile.get('open_data_url')  # get it if it has it
             }
 
             file_format = file_info["file_format"]
@@ -1738,7 +1740,7 @@ def files_not_registered_with_higlass(connection, **kwargs):
                 "raw" : connection.ff_s3.raw_file_bucket,
                 "proc" : connection.ff_s3.outfile_bucket,
             }
-            if not connection.ff_s3.does_key_exist(file_info['upload_key'], bucket=typebucket_by_cat[file_cat]):
+            if not file_info.get('open_data_url') or not connection.ff_s3.does_key_exist(file_info['upload_key'], bucket=typebucket_by_cat[file_cat]):
                 not_found_s3.append(file_info)
                 continue
 

--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -1853,8 +1853,6 @@ def patch_file_higlass_uid(connection, **kwargs):
     start_time = time.time()
     time_expired = False
 
-
-
     # Files to register is organized by filetype.
     to_be_registered = higlass_check_result.get('full_output', {}).get('files_not_registered')
     for ftype, hits in to_be_registered.items():
@@ -1875,7 +1873,10 @@ def patch_file_higlass_uid(connection, **kwargs):
             raw_bucket_types = ['chromsizes', 'beddb']
             out_bucket_types = ['mcool', 'bg', 'bw', 'bigbed', 'bed']
             if 'open_data_url' in hit:
-                payload["filepath"] = hit['open_data_url']
+                od_url = hit.get('open_data_url')
+                # conversion to correct filepath format relies on hardcoded values for expected url format
+                file_path = od_url.replace('.s3.amazonaws.com', '')[8:]
+                payload["filepath"] = file_path
             else:
                 if ftype in raw_bucket_types:
                     payload["filepath"] = connection.ff_s3.raw_file_bucket + "/" + hit['upload_key']

--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -1872,29 +1872,33 @@ def patch_file_higlass_uid(connection, **kwargs):
             # Based on the filetype, construct a payload to upload to the higlass server.
             payload = {}
             payload['coordSystem'] = hit['genome_assembly']
+            raw_bucket_types = ['chromsizes', 'beddb']
+            out_bucket_types = ['mcool', 'bg', 'bw', 'bigbed', 'bed']
+            if 'open_data_url' in hit:
+                payload["filepath"] = hit['open_data_url']
+            else:
+                if ftype in raw_bucket_types:
+                    payload["filepath"] = connection.ff_s3.raw_file_bucket + "/" + hit['upload_key']
+                elif ftype in out_bucket_types:
+                    payload["filepath"] = connection.ff_s3.outfile_bucket + "/" + hit['upload_key']
+
             if ftype == 'chromsizes':
-                payload["filepath"] = connection.ff_s3.raw_file_bucket + "/" + hit['upload_key']
                 payload['filetype'] = 'chromsizes-tsv'
                 payload['datatype'] = 'chromsizes'
             elif ftype == 'beddb':
-                payload["filepath"] = connection.ff_s3.raw_file_bucket + "/" + hit['upload_key']
                 payload['filetype'] = 'beddb'
                 payload['datatype'] = 'gene-annotation'
             elif ftype == 'mcool':
-                payload["filepath"] = connection.ff_s3.outfile_bucket + "/" + hit['upload_key']
                 payload['filetype'] = 'cooler'
                 payload['datatype'] = 'matrix'
             elif ftype in ['bg', 'bw', 'bigbed']:
                 # bigbeds can be registered the same way as bigwigs
-                payload["filepath"] = connection.ff_s3.outfile_bucket + "/" + hit['upload_key']
                 payload['filetype'] = 'bigwig'
                 payload['datatype'] = 'vector'
             elif ftype == 'bed' and hit['upload_key'].endswith(".bed.multires.mv5"):
-                payload["filepath"] = connection.ff_s3.outfile_bucket + "/" + hit['upload_key']
                 payload['filetype'] = 'multivec'
                 payload['datatype'] = 'multivec'
             elif ftype == 'bed':
-                payload["filepath"] = connection.ff_s3.outfile_bucket + "/" + hit['upload_key']
                 payload['filetype'] = 'beddb'
                 payload['datatype'] = 'bedlike'
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.4.43"
+version = "1.4.44"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Because open_data_url is a calcprop that checks to see if a file is present in the open data bucket if the property is present we don't double check but take it's word for it.  Is that sufficient?  or should an attempt be made to call does_key_exist function by parsing said url?

Registration process updated to use open_data_url as filepath payload.