### PR TITLE
Added parameter to allow appending of file to set that has existing processed files

### DIFF
--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -2231,7 +2231,7 @@ def insulation_scores_and_boundaries_start(connection, **kwargs):
     if kwargs.get('patch_completed'):
         patch_meta = insu_and_boun_check_result.get('completed_runs')
 
-    action = wfr_utils.start_tasks(missing_runs, patch_meta, action, my_auth, my_env, start, move_to_pc=True, runtype='insulation_scores_and_boundaries')
+    action = wfr_utils.start_tasks(missing_runs, patch_meta, action, my_auth, my_env, start, move_to_pc=True, runtype='insulation_scores_and_boundaries', pc_append=True)
     return action
 
 
@@ -2486,7 +2486,6 @@ def compartments_caller_status(connection, **kwargs):
     feature = 'compartments'
     contact_type = 'cis'
     binsize = 250000
-
     # completion tag
     tag = wfr_utils.feature_calling_accepted_versions[feature][-1]
     # check indexing queue
@@ -2592,7 +2591,7 @@ def compartments_caller_start(connection, **kwargs):
     if kwargs.get('patch_completed'):
         patch_meta = insu_and_boun_check_result.get('completed_runs')
 
-    action = wfr_utils.start_tasks(missing_runs, patch_meta, action, my_auth, my_env, start, move_to_pc=True, runtype='compartments')
+    action = wfr_utils.start_tasks(missing_runs, patch_meta, action, my_auth, my_env, start, move_to_pc=True, runtype='compartments', pc_append=True)
     return action
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.4.58"
+version = "1.4.59"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Needed for boundary and compartment pipelines.

These pipelines generate files that should be added to dataset items that already have other files in the processed_files fields.
The function that patches the metadata was expecting there to not being any existing processed files linked to the set.
Added a parameter to be used for pipelines like this that if True and there are existing processed files will append the files generated by the pipeline to the existing file list.