### PR TITLE
Fix bam re motif key error and add Arima re motif

### DIFF
--- a/chalicelib/checks/helpers/wfrset_utils.py
+++ b/chalicelib/checks/helpers/wfrset_utils.py
@@ -450,5 +450,10 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
     if overwrite:
         for a_key in overwrite:
             for a_spec in overwrite[a_key]:
-                template[a_key][a_spec] = overwrite[a_key][a_spec]
+                # if the key value is a dictionary, set default and use update
+                if isinstance(overwrite[a_key][a_spec], dict):
+                    template[a_key].setdefault(a_spec, {}).update(overwrite[a_key][a_spec])
+                # if it is string array bool, set the value
+                else:
+                    template[a_key][a_spec] = overwrite[a_key][a_spec]
     return template

--- a/chalicelib/checks/helpers/wfrset_utils.py
+++ b/chalicelib/checks/helpers/wfrset_utils.py
@@ -450,10 +450,11 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
     if overwrite:
         for a_key in overwrite:
             for a_spec in overwrite[a_key]:
+                template[a_key][a_spec] = overwrite[a_key][a_spec]
                 # if the key value is a dictionary, use update
-                if isinstance(overwrite[a_key][a_spec], dict):
-                    template[a_key][a_spec].update(overwrite[a_key][a_spec])
+                #if isinstance(overwrite[a_key][a_spec], dict): 
+                    #template[a_key].setdefault(a_spec, {}).update(overwrite[a_key][a_spec])
                 # if it is string array bool, set the value
-                else:
-                    template[a_key][a_spec] = overwrite[a_key][a_spec]
+                #else:
+                #    template[a_key][a_spec] = overwrite[a_key][a_spec]
     return template

--- a/chalicelib/checks/helpers/wfrset_utils.py
+++ b/chalicelib/checks/helpers/wfrset_utils.py
@@ -451,10 +451,4 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
         for a_key in overwrite:
             for a_spec in overwrite[a_key]:
                 template[a_key][a_spec] = overwrite[a_key][a_spec]
-                # if the key value is a dictionary, use update
-                #if isinstance(overwrite[a_key][a_spec], dict): 
-                    #template[a_key].setdefault(a_spec, {}).update(overwrite[a_key][a_spec])
-                # if it is string array bool, set the value
-                #else:
-                #    template[a_key][a_spec] = overwrite[a_key][a_spec]
     return template

--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -2018,7 +2018,7 @@ def bam_re_status(connection, **kwargs):
     # per https://github.com/4dn-dcic/docker-4dn-RE-checker/blob/master/scripts/4DN_REcount.pl#L74
     acceptable_enzymes = [  # "AluI",
         "NotI", "MboI", "DpnII", "HindIII", "NcoI", "MboI+HinfI", "HinfI+MboI",  # from the workflow
-        "MspI", "NcoI_MspI_BspHI", "DdeI", "DdeI and DpnII", "MseI"  # added patterns in action
+        "MspI", "NcoI_MspI_BspHI", "DdeI", "DdeI and DpnII", "MseI","Arima - A1, A2"  # added patterns in action
     ]
     # make a new list of files to work on
     filtered_res = []
@@ -2065,7 +2065,9 @@ def bam_re_start(connection, **kwargs):
         "NcoI_MspI_BspHI": {"motif": {"regex": ("CCATGCATGG|CCATGCATGA|CCATGCGG|TCATGCATGG|TCATGCATGA|TCATGCGG|"
                                                 "CCGCATGG|CCGCATGA|CCGCGG|GGTACGTACC|AGTACGTACC|GGCGTACC|GGTACGTACT|"
                                                 "AGTACGTACT|GGCGTACT|GGTACGCC|AGTACGCC|GGCGCC")}},
-        "MseI": {"motif": {"regex": "TTATA"}}}
+        "MseI": {"motif": {"regex": "TTATA"}},
+        "Arima - A1, A2": {"motif": {"regex": "GATCGATC|GA.TGATC|GA.TA.TC|GATCA.TC|"
+                                              "CT.ACTAG|CT.AT.AG|CTAGT.AG|CTAGCTAG"}}}
 
     if kwargs.get('start_missing_run'):
         targets.extend(bam_re_check_result.get('files_without_run', []))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.4.63"
+version = "1.4.64"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.4.62"
+version = "1.4.63"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Replaced the template overwrite step in step_settings method of wfrset_utils.py for cases where the dict does not yet have a key in the dict. E.g. if template = {'parameters': {}}, overwrite = {'parameters': {'motif': {'common_enz': 'MboI'}}}, then template['parameters']['common_enz'] does not exist to be overwritten.

Also added Arima motif for bam_re_check.