### PR TITLE
Fix for ChIP-seq logging via stepper and for peak caller for some experiments (TF target w/o control)

### DIFF
--- a/chalicelib/checks/helpers/wfrset_utils.py
+++ b/chalicelib/checks/helpers/wfrset_utils.py
@@ -202,7 +202,7 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
         "app_name": "encode-chipseq-aln-ctl",
         "workflow_uuid": "4dn-dcic-lab:wf-encode-chipseq-aln-ctl",
         "parameters": {},
-        "config": {},
+        "config": {"instance_type": "c5.4xlarge"},
         'custom_pf_fields': {
             'chip.first_ta_ctl': {
                 'genome_assembly': genome,

--- a/chalicelib/checks/helpers/wfrset_utils.py
+++ b/chalicelib/checks/helpers/wfrset_utils.py
@@ -186,7 +186,7 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
             "app_name": "encode-chipseq-aln-chip",
             "workflow_uuid": "4dn-dcic-lab:wf-encode-chipseq-aln-chip",
             "parameters": {},
-            "config": {},
+            "config": {"instance_type": "c5.4xlarge"},
             'custom_pf_fields': {
                 'chip.first_ta': {
                     'genome_assembly': genome,

--- a/chalicelib/checks/helpers/wfrset_utils.py
+++ b/chalicelib/checks/helpers/wfrset_utils.py
@@ -186,7 +186,7 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
             "app_name": "encode-chipseq-aln-chip",
             "workflow_uuid": "4dn-dcic-lab:wf-encode-chipseq-aln-chip",
             "parameters": {},
-            "config": {"instance_type": "c5.4xlarge"},
+            "config": {},
             'custom_pf_fields': {
                 'chip.first_ta': {
                     'genome_assembly': genome,
@@ -202,7 +202,7 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
         "app_name": "encode-chipseq-aln-ctl",
         "workflow_uuid": "4dn-dcic-lab:wf-encode-chipseq-aln-ctl",
         "parameters": {},
-        "config": {"instance_type": "c5.4xlarge"},
+        "config": {},
         'custom_pf_fields': {
             'chip.first_ta_ctl': {
                 'genome_assembly': genome,

--- a/chalicelib/checks/wfr_encode_checks.py
+++ b/chalicelib/checks/wfr_encode_checks.py
@@ -391,7 +391,7 @@ def chipseq_status(connection, **kwargs):
                     "chip.gensz": org,
                     "chip.xcor.cpu": 4,
                     "chip.spp_cpu": 4,
-                    "chip.spp_mem_mb": 24000 
+                    "chip.spp_mem_mb": 32000 
                 }
                 if paired == 'single':
                     frag_temp = [300]

--- a/chalicelib/checks/wfr_encode_checks.py
+++ b/chalicelib/checks/wfr_encode_checks.py
@@ -248,6 +248,8 @@ def chipseq_status(connection, **kwargs):
                     "chip.merge_fastq.cpu": 8,
                     "chip.filter.cpu": 8,
                     "chip.bam2ta.cpu": 8,
+                    "chip.xcor.cpu": 16,
+                    "chip.xcor.mem_mb": 20000,
                     "chip.align_only": True
                 }
                 parameters.update(exp_parameters)

--- a/chalicelib/checks/wfr_encode_checks.py
+++ b/chalicelib/checks/wfr_encode_checks.py
@@ -248,7 +248,6 @@ def chipseq_status(connection, **kwargs):
                     "chip.merge_fastq.cpu": 8,
                     "chip.filter.cpu": 8,
                     "chip.bam2ta.cpu": 8,
-                    "chip.xcor.cpu": 8,
                     "chip.align_only": True
                 }
                 parameters.update(exp_parameters)
@@ -391,7 +390,8 @@ def chipseq_status(connection, **kwargs):
                     "chip.gensz": org,
                     "chip.xcor.cpu": 4,
                     "chip.spp_cpu": 4,
-                    "chip.spp_mem_mb": 32000 
+                    # "chip.spp_mem_mb": 32000 
+                    "chip.peak_caller": "macs2"
                 }
                 if paired == 'single':
                     frag_temp = [300]

--- a/chalicelib/checks/wfr_encode_checks.py
+++ b/chalicelib/checks/wfr_encode_checks.py
@@ -248,7 +248,7 @@ def chipseq_status(connection, **kwargs):
                     "chip.merge_fastq.cpu": 8,
                     "chip.filter.cpu": 8,
                     "chip.bam2ta.cpu": 8,
-                    "chip.xcor.cpu": 16,
+                    "chip.xcor.cpu": 8,
                     "chip.align_only": True
                 }
                 parameters.update(exp_parameters)
@@ -390,13 +390,16 @@ def chipseq_status(connection, **kwargs):
                     "chip.qc_report.desc": run_ids['desc'],
                     "chip.gensz": org,
                     "chip.xcor.cpu": 4,
-                    "chip.spp_cpu": 4,
-                    "chip.peak_caller": "macs2"
                 }
                 if paired == 'single':
                     frag_temp = [300]
                     fraglist = frag_temp * len(ta)
                     parameters['chip.fraglen'] = fraglist
+
+                # if the target is a tf and there is no control, use macs2
+                if not control_set:
+                    if target_type == 'tf':
+                        parameters['chip.peak_caller'] = "macs2"
 
                 s2_tag = set_acc
                 # if complete, step1_output will have a list of 2 files, first_ta, and fist_ta_xcor

--- a/chalicelib/checks/wfr_encode_checks.py
+++ b/chalicelib/checks/wfr_encode_checks.py
@@ -249,7 +249,6 @@ def chipseq_status(connection, **kwargs):
                     "chip.filter.cpu": 8,
                     "chip.bam2ta.cpu": 8,
                     "chip.xcor.cpu": 16,
-                    "chip.xcor.mem_mb": 20000,
                     "chip.align_only": True
                 }
                 parameters.update(exp_parameters)
@@ -392,7 +391,6 @@ def chipseq_status(connection, **kwargs):
                     "chip.gensz": org,
                     "chip.xcor.cpu": 4,
                     "chip.spp_cpu": 4,
-                    # "chip.spp_mem_mb": 32000 
                     "chip.peak_caller": "macs2"
                 }
                 if paired == 'single':

--- a/chalicelib/checks/wfr_encode_checks.py
+++ b/chalicelib/checks/wfr_encode_checks.py
@@ -162,7 +162,7 @@ def chipseq_status(connection, **kwargs):
                     s0_tag = exp_id + '_p' + str(merge_enum)
                     keep, step0_status, step0_output = wfr_utils.stepper(library, keep,
                                                                          'step0', s0_tag, merge_case,
-                                                                         s0_input_files, step0_name, 'merged_fastq')
+                                                                         s0_input_files, step0_name, 'merged_fastq', organism=organism)
                     if step0_status == 'complete':
                         merged_files.append(step0_output)
                     else:
@@ -225,7 +225,7 @@ def chipseq_status(connection, **kwargs):
                 keep, step1c_status, step1c_output = wfr_utils.stepper(library, keep,
                                                                        'step1c', s1c_tag, exp_files,
                                                                        s1c_input_files, step1c_name, 'chip.first_ta_ctl',
-                                                                       additional_input={'parameters': parameters})
+                                                                       additional_input={'parameters': parameters}, organism=organism)
                 if step1c_status == 'complete':
                     # accumulate files to patch on experiment
                     patch_data = [step1c_output, ]
@@ -260,7 +260,7 @@ def chipseq_status(connection, **kwargs):
                 keep, step1_status, step1_output = wfr_utils.stepper(library, keep,
                                                                      'step1', s1_tag, exp_files,
                                                                      s1_input_files, step1_name, ['chip.first_ta', 'chip.first_ta_xcor'],
-                                                                     additional_input={'parameters': parameters})
+                                                                     additional_input={'parameters': parameters}, organism=organism)
                 if step1_status == 'complete':
                     exp_ta_file = step1_output[0]
                     exp_taxcor_file = step1_output[1]
@@ -406,7 +406,7 @@ def chipseq_status(connection, **kwargs):
                                                                      'step2', s2_tag, ta,
                                                                      s2_input_files, step2_name,
                                                                      ['chip.optimal_peak', 'chip.conservative_peak', 'chip.sig_fc'],
-                                                                     additional_input={'parameters': parameters})
+                                                                     additional_input={'parameters': parameters}, organism=organism)
                 if step2_status == 'complete':
                     set_opt_peak = step2_output[0]
                     set_cons_peak = step2_output[1]

--- a/chalicelib/checks/wfr_encode_checks.py
+++ b/chalicelib/checks/wfr_encode_checks.py
@@ -390,7 +390,8 @@ def chipseq_status(connection, **kwargs):
                     "chip.qc_report.desc": run_ids['desc'],
                     "chip.gensz": org,
                     "chip.xcor.cpu": 4,
-                    "chip.spp_cpu": 4
+                    "chip.spp_cpu": 4,
+                    "chip.spp_mem_mb": 24000 
                 }
                 if paired == 'single':
                     frag_temp = [300]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.4.64"
+version = "1.4.65"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Without a specified organism, stepper fn defaults to human, which can result in confusing logs. To fix, organism added to stepper calls. Also, experiments with a transcription factor target and no control should use macs2 for peak calling to avoid errors. To fix, added a conditional to specify this parameter.