### PR TITLE
State machine fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 *.DS_Store
 htmlcov/
 coverage.xml
+.python-version
 *.ipynb
 !*LocalTest.ipynb
 requirements.txt

--- a/chalicelib/checks/helpers/wfr_utils.py
+++ b/chalicelib/checks/helpers/wfr_utils.py
@@ -1487,7 +1487,10 @@ def patch_complete_data(patch_data, pipeline_type, auth, move_to_pc=False, pc_ap
     return log
 
 
-def run_missing_wfr(input_json, input_files_and_params, run_name, auth, env, mount=False):
+def run_missing_wfr(input_json, input_files_and_params, run_name, auth, env, fs_env, mount=False):
+    if fs_env == 'staging':
+        raise ValueError("'staging' not an expected value for fs_env - pipelines do not run on staging."
+                         "please run on data instead.")
     all_inputs = []
     # input_files container
     input_files = {k: v for k, v in input_files_and_params.items() if k != 'additional_file_parameters'}
@@ -1524,8 +1527,10 @@ def run_missing_wfr(input_json, input_files_and_params, run_name, auth, env, mou
     # print(json_object)
     # return
 
+    # env should be either data, webdev or fourfront-webdev
+
     try:
-        sfn = 'tibanna_pony_' + env.replace('fourfront-', '')  # env should be either data, webdev or fourfront-webdev
+        sfn = 'tibanna_pony_' + fs_env
         res = API().run_workflow(input_json, sfn=sfn, verbose=False)
         url = res['_tibanna']['url']
         return url

--- a/chalicelib/checks/helpers/wfr_utils.py
+++ b/chalicelib/checks/helpers/wfr_utils.py
@@ -1504,6 +1504,7 @@ def run_missing_wfr(input_json, input_files_and_params, run_name, auth, env, fs_
     all_inputs = sorted(all_inputs, key=itemgetter('workflow_argument_name'))
     my_s3_util = s3Utils(env=env)
     out_bucket = my_s3_util.outfile_bucket
+    sfn = 'tibanna_pony_' + fs_env
     # shorten long name_tags
     # they get combined with workflow name, and total should be less then 80
     # (even less since repeats need unique names)
@@ -1518,6 +1519,8 @@ def run_missing_wfr(input_json, input_files_and_params, run_name, auth, env, fs_
         "run_type": input_json['app_name'],
         "run_id": run_name}
     input_json['public_postrun_json'] = True
+    input_json['step_function_name'] = sfn
+    input_json['env_name'] = env
     if mount:
         for a_file in input_json['input_files']:
             a_file['mount'] = True
@@ -1530,7 +1533,6 @@ def run_missing_wfr(input_json, input_files_and_params, run_name, auth, env, fs_
     # env should be either data, webdev or fourfront-webdev
 
     try:
-        sfn = 'tibanna_pony_' + fs_env
         res = API().run_workflow(input_json, sfn=sfn, verbose=False)
         url = res['_tibanna']['url']
         return url

--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -72,7 +72,10 @@ def md5run_extra_file_start(connection, **kwargs):
         for extra_format in extra_formats:
             inp_f = {'input_file': a_file['@id'],
                      'additional_file_parameters': {'input_file': {'format_if_extra': extra_format}}}
-            url = wfr_utils.run_missing_wfr(wfr_setup, inp_f, a_file['accession'], connection.ff_keys, connection.ff_env, mount=True)
+            url = wfr_utils.run_missing_wfr(
+                wfr_setup, inp_f, a_file['accession'],
+                connection.ff_keys, connection.ff_env, connection.fs_env, mount=True
+            )
             # aws run url
             if url.startswith('http'):
                 action_logs['runs_started'].append(url)
@@ -226,7 +229,10 @@ def md5run_start(connection, **kwargs):
         inp_f = {'input_file': a_file['@id']}
         wfr_setup = wfrset_utils.step_settings('md5', 'no_organism', attributions)
 
-        url = wfr_utils.run_missing_wfr(wfr_setup, inp_f, a_file['accession'], connection.ff_keys, connection.ff_env, mount=True)
+        url = wfr_utils.run_missing_wfr(
+            wfr_setup, inp_f, a_file['accession'],
+            connection.ff_keys, connection.ff_env, connection.fs_env, mount=True
+        )
         # aws run url
         if url.startswith('http'):
             action_logs['runs_started'].append(url)
@@ -304,7 +310,7 @@ def fastqc_start(connection, **kwargs):
         inp_f = {'input_fastq': a_file['@id']}
         wfr_setup = wfrset_utils.step_settings('fastqc', 'no_organism', attributions)
         url = wfr_utils.run_missing_wfr(wfr_setup, inp_f, a_file['accession'],
-                                        connection.ff_keys, connection.ff_env, mount=True)
+                                        connection.ff_keys, connection.ff_env, connection.fs_env, mount=True)
         # aws run url
         if url.startswith('http'):
             action_logs['runs_started'].append(url)
@@ -398,7 +404,10 @@ def pairsqc_start(connection, **kwargs):
                                                'no_organism',
                                                attributions,
                                                overwrite=additional_setup)
-        url = wfr_utils.run_missing_wfr(wfr_setup, inp_f, a_file['accession'], connection.ff_keys, connection.ff_env, mount=False)
+        url = wfr_utils.run_missing_wfr(
+            wfr_setup, inp_f, a_file['accession'],
+            connection.ff_keys, connection.ff_env, connection.fs_env, mount=False
+        )
         # aws run url
         if url.startswith('http'):
             action_logs['runs_started'].append(url)
@@ -495,7 +504,10 @@ def bg2bw_start(connection, **kwargs):
         wfr_setup = wfrset_utils.step_settings('bedGraphToBigWig',
                                                'no_organism',
                                                attributions)
-        url = wfr_utils.run_missing_wfr(wfr_setup, inp_f, a_file['accession'], connection.ff_keys, connection.ff_env, mount=True)
+        url = wfr_utils.run_missing_wfr(
+            wfr_setup, inp_f, a_file['accession'],
+            connection.ff_keys, connection.ff_env, connection.fs_env, mount=True
+        )
         # aws run url
         if url.startswith('http'):
             action_logs['runs_started'].append(url)
@@ -608,7 +620,10 @@ def bed2beddb_start(connection, **kwargs):
         wfr_setup = wfrset_utils.step_settings('bedtobeddb',
                                                'no_organism',
                                                attributions)
-        url = wfr_utils.run_missing_wfr(wfr_setup, inp_f, a_file['accession'], connection.ff_keys, connection.ff_env, mount=True)
+        url = wfr_utils.run_missing_wfr(
+            wfr_setup, inp_f, a_file['accession'],
+            connection.ff_keys, connection.ff_env, connection.fs_env, mount=True
+        )
         # aws run url
         if url.startswith('http'):
             action_logs['runs_started'].append(url)
@@ -1609,7 +1624,9 @@ def bed2multivec_start(connection, **kwargs):
         wfr_setup = wfrset_utils.step_settings('bedtomultivec',
                                                'no_organism',
                                                attributions, parameters)
-        url = wfr_utils.run_missing_wfr(wfr_setup, inp_f, a_file['accession'], connection.ff_keys, connection.ff_env)
+        url = wfr_utils.run_missing_wfr(
+            wfr_setup, inp_f, a_file['accession'], connection.ff_keys, connection.ff_env, connection.fs_env
+        )
         # aws run url
         if url.startswith('http'):
             action_logs['runs_started'].append(url)
@@ -1726,7 +1743,9 @@ def rna_strandedness_start(connection, **kwargs):
         wfr_setup = wfrset_utils.step_settings('rna-strandedness',
                                                'no_organism',
                                                attributions)
-        url = wfr_utils.run_missing_wfr(wfr_setup, inp_f, a_file['accession'], connection.ff_keys, connection.ff_env)
+        url = wfr_utils.run_missing_wfr(
+            wfr_setup, inp_f, a_file['accession'], connection.ff_keys, connection.ff_env, connection.fs_env
+        )
         # aws run url
         if url.startswith('http'):
             action_logs['runs_started'].append(url)
@@ -1871,7 +1890,10 @@ def bamqc_start(connection, **kwargs):
         wfr_setup = wfrset_utils.step_settings('bamqc',
                                                'no_organism',
                                                attributions)
-        url = wfr_utils.run_missing_wfr(wfr_setup, inp_f, a_file['accession'], connection.ff_keys, connection.ff_env, mount=True)
+        url = wfr_utils.run_missing_wfr(
+            wfr_setup, inp_f, a_file['accession'],
+            connection.ff_keys, connection.ff_env, connection.fs_env, mount=True
+        )
         # aws run url
         if url.startswith('http'):
             action_logs['runs_started'].append(url)
@@ -1968,7 +1990,10 @@ def fastq_first_line_start(connection, **kwargs):
         wfr_setup = wfrset_utils.step_settings('fastq-first-line',
                                                'no_organism',
                                                attributions)
-        url = wfr_utils.run_missing_wfr(wfr_setup, inp_f, a_file['accession'], connection.ff_keys, connection.ff_env, mount=True)
+        url = wfr_utils.run_missing_wfr(
+            wfr_setup, inp_f, a_file['accession'],
+            connection.ff_keys, connection.ff_env, connection.fs_env, mount=True
+        )
         # aws run url
         if url.startswith('http'):
             action_logs['runs_started'].append(url)
@@ -2090,7 +2115,10 @@ def bam_re_start(connection, **kwargs):
                                                'no_organism',
                                                attributions,
                                                overwrite=additional_setup)
-        url = wfr_utils.run_missing_wfr(wfr_setup, inp_f, a_file['accession'], connection.ff_keys, connection.ff_env, mount=True)
+        url = wfr_utils.run_missing_wfr(
+            wfr_setup, inp_f, a_file['accession'],
+            connection.ff_keys, connection.ff_env, connection.fs_env, mount=True
+        )
         # aws run url
         if url.startswith('http'):
             action_logs['runs_started'].append(url)
@@ -2669,7 +2697,9 @@ def mcoolqc_start(connection, **kwargs):
         wfr_setup = wfrset_utils.step_settings('mcoolQC',
                                                'no_organism',
                                                attributions)
-        url = wfr_utils.run_missing_wfr(wfr_setup, inp_f, a_file['accession'], connection.ff_keys, connection.ff_env, mount=True)
+        url = wfr_utils.run_missing_wfr(
+            wfr_setup, inp_f, a_file['accession'], connection.ff_keys, connection.ff_env, connection.fs_env, mount=True
+        )
         # aws run url
         if url.startswith('http'):
             action_logs['runs_started'].append(url)
@@ -2732,7 +2762,9 @@ def template_start(connection, **kwargs):
         attributions = wfr_utils.get_attribution(a_file)
         inp_f = {'input_fastq': a_file['@id']}
         wfr_setup = wfrset_utils.step_settings('template', 'no_organism', attributions)
-        url = wfr_utils.run_missing_wfr(wfr_setup, inp_f, a_file['accession'], connection.ff_keys, connection.ff_env)
+        url = wfr_utils.run_missing_wfr(
+            wfr_setup, inp_f, a_file['accession'], connection.ff_keys, connection.ff_env, connection.fs_env
+        )
         # aws run url
         if url.startswith('http'):
             action_logs['runs_started'].append(url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.6.1"
+version = "1.6.2"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Fixes a problem where the wrong state machine was being specified in wfr input_json.

- `run_missing_wfr` now uses fs_env for state machine suffix rather than ff_env (to get 'data' instead of 'blue' or 'green')
- `run_missing_wfr` also raises a ValueError if 'staging' is the fs_env - since data and staging share a DB then we should only run wfrs on data
- wfr actions updated to add new argument (connection.fs_env)