### PR TITLE
Upd hg chk bug

### DIFF
--- a/chalicelib/checks/higlass_checks.py
+++ b/chalicelib/checks/higlass_checks.py
@@ -186,11 +186,13 @@ def add_viewconf_static_content_to_file(connection, item_uuid, higlass_item_uuid
     # Look through the static content to see if this section exists already.
     reuse_existing = False
     for sc in patched_static_content:
-        if sc["description"] == "auto_generated_higlass_view_config":
+        if "description" in sc and sc["description"] == "auto_generated_higlass_view_config":
             sc.update(new_sc_section)
             reuse_existing = True
-            break
-
+        else:
+            sc_content = sc.get('content')
+            if sc_content and 'uuid' in sc_content:
+                sc['content'] = sc_content.get('uuid')
     # If there is no existing Higlass static content, add the new content to the existing static_content
     if not reuse_existing:
         patched_static_content = static_content_section + [new_sc_section]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.6.11"
+version = "1.6.12"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Update a higlass function that adds viewconfs to items - the code did not expect there to be existing static content that may lack the 'description' property so an exception was thrown when that case was encountered.  

The fix maintains any existing static content by replacing the object (or embedded) view of the content with its uuid but if an existing autogenerated higlass viewconf is found replaces the content with the newly generated viewconf.