### PR TITLE
Check md5sum on released files

### DIFF
--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -1165,6 +1165,20 @@
             }
         }
     },
+    "md5run_released_files": {
+        "title": "a) MD5run released files",
+        "group": "Pipeline checks",
+        "schedule": {
+            "hourly_checks_3": {
+                "data": {
+                    "dependencies": [],
+                    "kwargs": {
+                        "primary": true
+                    }
+                }
+            }
+        }
+    },
     "micro_c_status": {
         "title": "d) Micro-C",
         "group": "Pipeline checks",

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -1169,7 +1169,7 @@
         "title": "a) MD5run released files",
         "group": "Pipeline checks",
         "schedule": {
-            "hourly_checks_3": {
+            "morning_checks_4": {
                 "data": {
                     "dependencies": [],
                     "kwargs": {

--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -217,7 +217,7 @@ def md5run_released_files(connection, **kwargs):
         return check
     # Build the query
     statuses = ['pre-release', 'released',  # 'released to project', 'archived to project'
-                'archived', 'replaced']
+                'uploaded', 'archived', 'replaced']
     query = '/search/?type=File&md5sum=No+value' + ''.join(['&status=' + s for s in statuses])
 
     files = {}

--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -228,7 +228,7 @@ def md5run_released_files(connection, **kwargs):
 
     if files:
         check.status = 'WARN'
-        check.brief_output = {k: str(len(v)) + ' files' for k, v in files}
+        check.brief_output = {k: str(len(v)) + ' files' for k, v in files.items()}
         check.full_output = files
         if files['released_without_md5run']:
             check.allow_action = True

--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -226,7 +226,7 @@ def md5run_released_files(connection, **kwargs):
     files['released_with_md5run'] = [f['accession'] for f in ff_utils.search_metadata(
         query + '&workflow_run_inputs.workflow.title=md5+0.2.6', key=my_auth)]
 
-    if files:
+    if files['released_without_md5run'] or files['released_with_md5run']:
         check.status = 'WARN'
         check.brief_output = {k: str(len(v)) + ' files' for k, v in files.items()}
         check.full_output = files

--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -216,8 +216,8 @@ def md5run_released_files(connection, **kwargs):
     if skip:
         return check
     # Build the query
-    statuses = ['pre-release', 'released to project',  'released',
-                'archived to project', 'archived', 'replaced']
+    statuses = ['pre-release', 'released',  # 'released to project', 'archived to project'
+                'archived', 'replaced']
     query = '/search/?type=File&md5sum=No+value' + ''.join(['&status=' + s for s in statuses])
 
     files = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.6.12"
+version = "1.7.0"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
We want to make sure that all released files have md5sum. Files without previous md5 runs can be run automatically, while those with pre-existing md5run only trigger a warning and should be resolved manually. The statuses checked include pre-release and other public ones.