### PR TITLE
Fix assay subcls except

### DIFF
--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -1294,15 +1294,15 @@ def check_assay_classification_short_names(connection, **kwargs):
             value = subclass_dict[exptype['assay_subclassification'].lower()]
         else:
             manual[exptype['@id']] = {
-                'classification': exptype['assay_classification'],
-                'subclassification': exptype['assay_subclassification'],
+                'classification': exptype.get('assay_classification'),
+                'subclassification': exptype.get('assay_subclassification'),
                 'current subclass_short': exptype.get('assay_subclass_short'),
                 'new subclass_short': 'N/A - Attention needed'
             }
         if value and exptype.get('assay_subclass_short') != value:
             auto_patch[exptype['@id']] = {
-                'classification': exptype['assay_classification'],
-                'subclassification': exptype['assay_subclassification'],
+                'classification': exptype.get('assay_classification'),
+                'subclassification': exptype.get('assay_subclassification'),
                 'current subclass_short': exptype.get('assay_subclass_short'),
                 'new subclass_short': value
             }

--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -1257,6 +1257,7 @@ def check_assay_classification_short_names(connection, **kwargs):
         "replication timing": "Replication timing",
         "proximity to cellular component": "Proximity-seq",
         "dna binding": "DNA binding",
+        "dna damage detection": "DNA damage detection",
         "open chromatin": "Open Chromatin",
         "open chromatin - single cell": "Open Chromatin",
         "dna-dna pairwise interactions": "Hi-C",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.7.0"
+version = "1.7.1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Updated the check_assay_subclass_short to use .get instead of automatically expecting properties and throwing KeyError exceptions if not present.  

Added DNA damage detection to subclass_short mapping.