### PR TITLE
Enzyme error fix

### DIFF
--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -2152,6 +2152,7 @@ def bam_re_status(connection, **kwargs):
         check.summary += ', ' + message
         check.brief_output.insert(0, message)
         check.full_output['skipped_no_enzyme'] = [i['accession'] for i in no_nz]
+    check.summary = check.summary.lstrip(',').lstrip()
     return check
 
 

--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -2123,7 +2123,8 @@ def bam_re_status(connection, **kwargs):
         nz = a_file.get('experiments')[0].get('digestion_enzyme', {}).get('name')
         if nz in acceptable_enzymes:
             filtered_res.append(a_file)
-        else:
+        # make sure nz is not None 
+        elif nz:
             missing_nz_files.append(a_file)
             if nz not in missing_nz:
                 missing_nz.append(nz)

--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -2074,7 +2074,7 @@ def fastq_first_line_start(connection, **kwargs):
 @check_function()
 def bam_re_status(connection, **kwargs):
     """Searches for fastq files that don't have bam_re
-    
+
     If a file has an associated enzyme that isn't in the list of acceptable enzymes,
     or if it has no associated enzyme, it will be added to the list of skipped files.
     """
@@ -2130,10 +2130,12 @@ def bam_re_status(connection, **kwargs):
         if nz in acceptable_enzymes:
             filtered_res.append(a_file)
         # make sure nz is not None
-        else:
+        elif nz:
             missing_nz_files.append(a_file)
             if nz not in missing_nz:
-                missing_nz.append(str(nz))
+                missing_nz.append(nz)
+        else:
+            no_nz.append(a_file)
 
 
     check = wfr_utils.check_runs_without_output(filtered_res, check, 're_checker_workflow', my_auth, start)
@@ -2145,6 +2147,11 @@ def bam_re_status(connection, **kwargs):
         check.brief_output.insert(0, message)
         check.full_output['skipped'] = [i['accession'] for i in missing_nz_files]
         check.status = 'WARN'
+    if no_nz:
+        message = 'INFO: skipping files ({}) without an associated enzyme'.format(len(no_nz))
+        check.summary += ', ' + message
+        check.brief_output.insert(0, message)
+        check.full_output['skipped_no_enzyme'] = [i['accession'] for i in no_nz]
     return check
 
 

--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -827,7 +827,7 @@ def tcc_status(connection, **kwargs):
     if not res:
         check.summary = 'All Good!'
         return check
-    check = wfr_utils.check_hic(res, my_auth, tag, check, start, lambda_limit, nore=True, nonorm=False)
+    check = wfr_utils.check_hic(res, my_auth, tag, check, start, lambda_limit, nore=False, nonorm=False)
     return check
 
 

--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -2099,7 +2099,7 @@ def bam_re_status(connection, **kwargs):
                  # 'in+situ+ChIA-PET',
                  'PLAC-seq']
     query = ("/search/?file_format.file_format=bam&file_type=alignments&type=FileProcessed"
-             "&status!=uploading&status!=to be uploaded by workflow")
+             "&status!=uploading&status!=to be uploaded by workflow&tags!=skip_processing")
     exp_type_key = '&track_and_facet_info.experiment_type='
     exp_type_filter = exp_type_key + exp_type_key.join(exp_types)
     exclude_processed = '&percent_clipped_sites_with_re_motif=No value'
@@ -2152,6 +2152,7 @@ def bam_re_status(connection, **kwargs):
         check.summary += ', ' + message
         check.brief_output.insert(0, message)
         check.full_output['skipped_no_enzyme'] = [i['accession'] for i in no_nz]
+        check.status = 'WARN'
     check.summary = check.summary.lstrip(',').lstrip()
     return check
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.8.0"
+version = "1.8.1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
The bam_re_status check had been erroring because of some files that were expected to have a restriction enzyme but did not, resulting in an error when the function attempted to perform a join() on a list containing None values. 

To fix this I added some separate logic for storing and outputting files without restriction enzymes, which also get skipped by the action.