### PR TITLE
Tweak repno badge chk

### DIFF
--- a/chalicelib/checks/badge_checks.py
+++ b/chalicelib/checks/badge_checks.py
@@ -406,13 +406,15 @@ def repsets_have_bio_reps(connection, **kwargs):
         k: {'single_biorep': [], 'biorep_nums': [], 'techrep_nums': []} for k in check.full_output.keys()
     }
     for k, v in audits[RELEASED_KEY].items():
+        nochg_cnt = 0
         for item in v:
             name = item.split(' ')[0]
             for key in ["Add badge", 'Remove badge', 'Keep badge and edit messages']:
                 if name in check.full_output[key].keys():
                     check.brief_output[RELEASED_KEY][key][k].append(item)
             if name in check.full_output['Keep badge (no change)']:
-                check.brief_output[RELEASED_KEY]['Keep badge (no change)'][k].append(item)
+                nochg_cnt += 1
+        check.brief_output[RELEASED_KEY]['Keep badge (no change)'][k] = nochg_cnt
     return check
 
 

--- a/chalicelib/checks/badge_checks.py
+++ b/chalicelib/checks/badge_checks.py
@@ -400,7 +400,7 @@ def repsets_have_bio_reps(connection, **kwargs):
     check.full_output = {'Add badge': to_add,
                          'Remove badge': to_remove,
                          'Keep badge and edit messages': to_edit,
-                         'Keep badge (no change)': ok}
+                         'Keep badge (no change)': len(ok)}
     check.brief_output = {REV_KEY: audits[REV_KEY]}
     check.brief_output[RELEASED_KEY] = {
         k: {'single_biorep': [], 'biorep_nums': [], 'techrep_nums': []} for k in check.full_output.keys()
@@ -412,7 +412,7 @@ def repsets_have_bio_reps(connection, **kwargs):
             for key in ["Add badge", 'Remove badge', 'Keep badge and edit messages']:
                 if name in check.full_output[key].keys():
                     check.brief_output[RELEASED_KEY][key][k].append(item)
-            if name in check.full_output['Keep badge (no change)']:
+            if name in ok:
                 nochg_cnt += 1
         check.brief_output[RELEASED_KEY]['Keep badge (no change)'][k] = nochg_cnt
     return check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.8.1"
+version = "1.8.2"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
I modified the brief output of the badge check that looks at replicate number badges.
The number of replicates with badges that do not need to change is so large that you can't view either the brief or full output.  
I modified the check so that at least we can see the brief output without looking at the json by reporting the number of sets with a badge for which there is no change needed rather than the @ids.  The items that will get badges added or removed are still shown, allowing us to confirm that the action should be run.  