### PR TITLE
update authors search

### DIFF
--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -273,7 +273,7 @@ def biorxiv_is_now_published(connection, **kwargs):
             do_author_search = True  # problem with request to pubmed
 
         if do_author_search and authors:
-            author_string = '&term=' + '%20'.join(['{}[Author]'.format(a.split(' ')[-1]) for a in authors])
+            author_string = '&term=' + '%20'.join(['{}[Author]'.format(a.split(',')[0]) for a in authors])
             author_query = pubmed_url + author_string
             time.sleep(1)
             res = requests.get(author_query)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.8.2"
+version = "1.8.3"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Since updating the way publications are retrieved from bioRxiv in fourfront, authors have a different format (first names are not available, just initials). Therefore, the published biorxiv check needs to be updated.