### PR TITLE
Update biorxivs

### DIFF
--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -106,6 +106,20 @@
             }
         }
     },
+    "biorxiv_version_update": {
+        "title": "biorxiv version update",
+        "group": "Metadata checks",
+        "schedule": {
+            "monthly_checks": {
+                "data": {
+                    "dependencies": [],
+                    "kwargs": {
+                        "primary": true
+                    }
+                }
+            }
+        }
+    },
     "biosource_cell_line_value": {
         "title": "Cell line biosources without cell_line metadata",
         "group": "Audit checks",

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -110,7 +110,7 @@
         "title": "biorxiv version update",
         "group": "Metadata checks",
         "schedule": {
-            "monthly_checks": {
+            "monday_checks": {
                 "data": {
                     "dependencies": [],
                     "kwargs": {

--- a/chalicelib/checks/wrangler_checks.py
+++ b/chalicelib/checks/wrangler_checks.py
@@ -557,7 +557,10 @@ def reindex_biorxiv(connection, **kwargs):
             action_logs['patch_failure'].append({biorxiv['uuid']: str(e)})
         else:
             action_logs['patch_success'].append(biorxiv['uuid'])
-    action.status = 'DONE'
+    if action_logs['patch_failure']:
+        action.status = 'FAIL'
+    else:
+        action.status = 'DONE'
     action.output = action_logs
     return action
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.8.4"
+version = "1.9.0"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
BioRxiv stores different versions of a manuscript. We should make sure that we have the most recent one in the database, especially regarding title and list of authors, since these metadata are used by another check in foursight to search in Pubmed when the manuscript is published.