### PR TITLE
update RNAseq strandedness tags check

### DIFF
--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -1703,7 +1703,7 @@ def bed2multivec_start(connection, **kwargs):
 
 @check_function(lab_title=None, start_date=None)
 def rna_strandedness_status(connection, **kwargs):
-    """Searches for fastq files of experiment seq type that don't have beta_actin_count fields
+    """Searches for fastq files from RNA-seq that don't have beta_actin_count fields
     Keyword arguments:
     lab_title -- limit search with a lab i.e. Bing+Ren, UCSD
     start_date -- limit search to files generated since a date formatted YYYY-MM-DD
@@ -1721,25 +1721,34 @@ def rna_strandedness_status(connection, **kwargs):
     check, skip = wfr_utils.check_indexing(check, connection)
     if skip:
         return check
-    # Build the query (RNA-seq experiments)
-    query = ('/search/?experiment_type.display_title=RNA-seq&type=ExperimentSeq&biosample.biosource.organism.name!=No+value'
-             '&status=pre-release&status=released&status=released to project&tags!=skip_processing')
+    # Get Fastq files from RNA-seq that are missing beta-actin counts
+    files = ff_utils.search_metadata(
+        '/search/?type=FileFastq&file_format.file_format=fastq&track_and_facet_info.experiment_type=RNA-seq'
+        + '&experiments.biosample.biosource.organism.name!=No+value'
+        + '&beta_actin_sense_count=No+value&beta_actin_antisense_count=No+value'
+        + '&status=pre-release&status=released&status=released to project',
+        key=my_auth)
+    # Get RNA-seq sets that are tagged with skip_processing
+    expsets_to_skip = ff_utils.search_metadata(
+        '/search/?type=ExperimentSetReplicate&experiments_in_set.experiment_type.display_title=RNA-seq'
+        + '&experiments_in_set.biosample.biosource.organism.name!=No+value'
+        + '&status=pre-release&status=released&status=released to project'
+        + '&tags=skip_processing&field=accession',
+        key=my_auth)
+    expsets_acc_to_skip = [expset['accession'] for expset in expsets_to_skip]
 
-    # The search
-    res = ff_utils.search_metadata(query, key=my_auth)
     targets = []
-    for re in res:
-        for a_re_file in re['files']:
-            if a_re_file['file_format']['display_title'] == 'fastq':
-                file_meta = ff_utils.get_metadata(a_re_file['accession'], key=my_auth)
-                file_meta_keys = file_meta.keys()
-                if 'beta_actin_sense_count' not in file_meta_keys and 'beta_actin_antisense_count' not in file_meta_keys:
-                    org = re['biosample']['biosource'][0]['organism']['name']
-                    kmer_file = wfr_utils.re_kmer.get(org)
-                    if kmer_file:
-                        targets.append(file_meta)
-                    else:
-                        problematic.append([file_meta['accession'], 'missing re_kmer reference file for %s'%(org)])
+    for a_file in files:
+        replicate_expsets = [es['accession'] for es in a_file['experiments'][0]['experiment_sets'] if es['experimentset_type'] == 'replicate']
+        if replicate_expsets and replicate_expsets[0] in expsets_acc_to_skip:
+            continue  # skip this file if the expset is tagged with skip_processing
+
+        org = a_file['experiments'][0]['biosample']['biosource'][0]['organism']['name']
+        kmer_file = wfr_utils.re_kmer.get(org)
+        if kmer_file:
+            targets.append(a_file)
+        else:
+            problematic.append([a_file['accession'], 'missing re_kmer reference file for %s'%(org)])
 
     if not targets and not problematic:
         check.summary = "All good!"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.9.7"
+version = "1.9.8"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.9.6"
+version = "1.9.7"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
- expect `skip_processing` tag in the Experiment Set, rather than in the Experiment
- for improved performance, rewritten the check to do a single search for Files instead of recursively getting each single one