### PR TITLE
include files released to project in md5 check

### DIFF
--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -221,7 +221,7 @@ def md5run_released_files(connection, **kwargs):
     if skip:
         return check
     # Build the query
-    statuses = ['pre-release', 'released',  # 'released to project', 'archived to project'
+    statuses = ['pre-release', 'released', 'released to project', 'archived to project'
                 'uploaded', 'archived', 'replaced']
     query = '/search/?type=File&md5sum=No+value' + ''.join(['&status=' + s for s in statuses])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.9.11"
+version = "1.9.12"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
`released to project` and `archived to project` were initially excluded from the md5 check because some files were falling in this category and it was problematic to run the pipeline on them. Now that these are deleted it should be OK to add these statuses.