### PR TITLE
Rename md5 released to md5 uploaded

### DIFF
--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -682,7 +682,8 @@
                 "data": {
                     "dependencies": [],
                     "kwargs": {
-                        "primary": true
+                        "primary": true,
+                        "queue_action": "prod"
                     }
                 }
             }
@@ -1106,7 +1107,8 @@
                 "data": {
                     "dependencies": [],
                     "kwargs": {
-                        "primary": true
+                        "primary": true,
+                        "queue_action": "prod"
                     }
                 }
             }

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -1183,8 +1183,8 @@
             }
         }
     },
-    "md5run_released_files": {
-        "title": "a) MD5run released files",
+    "md5run_uploaded_files": {
+        "title": "a) MD5run uploaded files",
         "group": "Pipeline checks",
         "schedule": {
             "morning_checks_4": {

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -1191,7 +1191,8 @@
                 "data": {
                     "dependencies": [],
                     "kwargs": {
-                        "primary": true
+                        "primary": true,
+                        "queue_action": "prod"
                     }
                 }
             }

--- a/chalicelib/checks/wfr_checks.py
+++ b/chalicelib/checks/wfr_checks.py
@@ -210,9 +210,16 @@ def md5run_status(connection, **kwargs):
 
 
 @check_function()
-def md5run_released_files(connection, **kwargs):
-    """Search for (pre)released files that do not have md5sum (this should not happen)"""
-    check = CheckResult(connection, 'md5run_released_files')
+def md5run_uploaded_files(connection, **kwargs):
+    """
+    Search for Files with status uploaded (and higher) that do not have md5sum.
+
+    Since ENCODE pipelines do not add md5sum, ProcessedFiles from ATAC-seq,
+    ChIP-seq, and RNA-seq are expected to trigger this check.
+    All other files should have md5sum by the time they are uploaded, but this
+    check will find any exception.
+    """
+    check = CheckResult(connection, 'md5run_uploaded_files')
     my_auth = connection.ff_keys
     check.action = "md5run_start"
     check.status = 'PASS'
@@ -221,26 +228,27 @@ def md5run_released_files(connection, **kwargs):
     if skip:
         return check
     # Build the query
-    statuses = ['pre-release', 'released', 'released to project', 'archived to project',
-                'uploaded', 'archived', 'replaced']
+    statuses = ['uploaded', 'pre-release', 'released to project', 'released',
+                'archived to project', 'archived', 'replaced']
     query = '/search/?type=File&md5sum=No+value' + ''.join(['&status=' + s for s in statuses])
 
     files = {}
-    files['released_without_md5run'] = [f['accession'] for f in ff_utils.search_metadata(
+    files['uploaded_without_md5run'] = [f['accession'] for f in ff_utils.search_metadata(
         query + '&workflow_run_inputs.workflow.title%21=md5+0.2.6', key=my_auth)]
-    files['released_with_md5run'] = [f['accession'] for f in ff_utils.search_metadata(
+    files['uploaded_with_md5run'] = [f['accession'] for f in ff_utils.search_metadata(
         query + '&workflow_run_inputs.workflow.title=md5+0.2.6', key=my_auth)]
 
-    if files['released_without_md5run'] or files['released_with_md5run']:
+    if files['uploaded_without_md5run'] or files['uploaded_with_md5run']:
         check.status = 'WARN'
         check.summary = 'Some files need md5 run before release'
         check.description = 'Some files with status updloaded or higher are missing md5sum'
         check.brief_output = {k: str(len(v)) + ' files' for k, v in files.items()}
         check.full_output = files
-        if files['released_without_md5run']:
+        if files['uploaded_without_md5run']:
             check.allow_action = True
-        if files['released_with_md5run']:
-            check.action_message = 'Files with previous md5run CANNOT be run automatically'
+        if files['uploaded_with_md5run']:
+            check.action_message = ('Action will only run on Files without previous md5 run. ' +
+                                    'You need to manually fix those with previous md5 run.')
     else:
         check.summary = 'All Good!'
     return check
@@ -257,8 +265,10 @@ def md5run_start(connection, **kwargs):
     action_logs['check_output'] = md5run_check_result
     targets = []
     if kwargs.get('start_missing'):
+        # get uploading files from md5run_status
         targets.extend(md5run_check_result.get('files_without_md5run', []))
-        targets.extend(md5run_check_result.get('released_without_md5run', []))
+        # get uploaded files from md5run_uploaded_files
+        targets.extend(md5run_check_result.get('uploaded_without_md5run', []))
     if kwargs.get('start_not_switched'):
         targets.extend(md5run_check_result.get('files_with_run_and_wrong_status', []))
     action_logs['targets'] = targets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "1.9.13"
+version = "1.9.14"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
- rename check, variables and improve documentation for the `md5run_released_files` check (becoming `md5run_uploaded_files`)
- automate action for `md5run_uploaded_files`, `compartments_caller_status`, `insulation_scores_and_boundaries_status`