### PR TITLE
Check schedule edits

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ foursight
 Change Log
 ----------
 
+2.1.2
+=====
+
+* Update check schedule to reduce the number of metadata-related checks running on
+  staging and non-production environments.
+
+
 2.1.1
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Change Log
 2.1.2
 =====
 
+`PR 507: Check schedule edits <https://github.com/4dn-dcic/foursight/pull/507>`_
+
 * Update check schedule to reduce the number of metadata-related checks running on
   staging and non-production environments.
 

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -714,7 +714,7 @@
         "title": "Deploy Fourfront master to staging.4dnucleome.org",
         "group": "Deployment Checks",
         "schedule": {
-            "deployment_checks": {
+            "manual_checks": {
                 "data": {
                     "kwargs": {
                         "primary": true

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -120,7 +120,7 @@
         "group": "Audit checks",
         "schedule": {
             "morning_checks_1": {
-                "all": {
+                "data": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -528,7 +528,7 @@
         "group": "Audit checks",
         "schedule": {
             "morning_checks_1": {
-                "all": {
+                "data": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -556,7 +556,7 @@
         "group": "Audit checks",
         "schedule": {
             "morning_checks_2": {
-                "all": {
+                "data": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -584,7 +584,7 @@
         "group": "Audit checks",
         "schedule": {
             "morning_checks_3": {
-                "all": {
+                "data": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -688,7 +688,7 @@
         "group": "Badge checks",
         "schedule": {
             "morning_checks_1": {
-                "all": {
+                "data": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -800,7 +800,7 @@
         "group": "Badge checks",
         "schedule": {
             "morning_checks_2": {
-                "all": {
+                "data": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -828,7 +828,7 @@
         "group": "Audit checks",
         "schedule": {
             "thirty_min_checks": {
-                "all": {
+                "data": {
                     "dependencies": [
                         "expset_opfsets_unique_titles"
                     ],
@@ -844,7 +844,7 @@
         "group": "Audit checks",
         "schedule": {
             "thirty_min_checks": {
-                "all": {
+                "data": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -858,7 +858,7 @@
         "group": "Audit checks",
         "schedule": {
             "morning_checks_1": {
-                "all": {
+                "data": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -1417,7 +1417,7 @@
         "group": "Static headers checks",
         "schedule": {
             "morning_checks_1": {
-                "all": {
+                "data": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -1574,7 +1574,7 @@
         "group": "Badge checks",
           "schedule": {
             "morning_checks_3": {
-                "all": {
+                "data": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -1790,7 +1790,7 @@
         "group": "Metadata checks",
         "schedule": {
             "morning_checks_4": {
-                "all": {
+                "data": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -168,15 +168,12 @@
                     "kwargs": {
                         "primary": true
                     }
-                },
-                "mastertest": {
-                    "dependencies": [],
-                    "kwargs": {
-                        "primary": true
-                    }
                 }
             }
-        }
+        },
+        "display": [
+            "mastertest"
+        ]
     },
     "check_bio_feature_organism_name": {
         "title": "BioFeatures with missing or mismatched organism_name",

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -152,7 +152,7 @@
         "group": "Metadata checks",
         "schedule": {
             "morning_checks_4": {
-                "all": {
+                "data": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -709,32 +709,6 @@
             "all"
         ]
     },
-    "deploy_application_to_beanstalk": {
-        "title": "Deploy Version to ElasticBeanstalk",
-        "group": "Deployment Checks",
-        "schedule": {
-            "manual_checks": {
-                "data": {
-                    "kwargs": {
-                        "primary": true
-                    }
-                }
-            }
-        }
-    },
-    "deploy_ff_staging": {
-        "title": "Deploy Fourfront master to staging.4dnucleome.org",
-        "group": "Deployment Checks",
-        "schedule": {
-            "manual_checks": {
-                "data": {
-                    "kwargs": {
-                        "primary": true
-                    }
-                }
-            }
-        }
-    },
     "dilution_hic_status": {
         "title": "d) Dilution Hi-C",
         "group": "Pipeline checks",
@@ -1060,19 +1034,6 @@
             }
         }
     },
-    "indexer_server_status": {
-        "title": "Indexer Server Status",
-        "group": "Deployment Checks",
-        "schedule": {
-            "manual_checks": {
-                "data": {
-                    "kwargs": {
-                        "primary": true
-                    }
-                }
-            }
-        }
-    },
     "indexing_progress": {
         "title": "Indexing progress",
         "conditions": [
@@ -1081,7 +1042,15 @@
         "group": "Elasticsearch checks",
         "schedule": {
             "hourly_checks_1": {
-                "all": {
+                "data": {
+                    "dependencies": [
+                        "item_counts_by_type"
+                    ],
+                    "kwargs": {
+                        "primary": true
+                    }
+                },
+                "staging": {
                     "dependencies": [
                         "item_counts_by_type"
                     ],
@@ -1129,7 +1098,13 @@
         "group": "Metadata checks",
         "schedule": {
             "hourly_checks_1": {
-                "all": {
+                "data": {
+                    "dependencies": [],
+                    "kwargs": {
+                        "primary": true
+                    }
+                },
+                "staging": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -1522,19 +1497,6 @@
             }
         }
     },
-    "provision_indexer_environment": {
-        "title": "Provision Indexer Environment",
-        "group": "Deployment Checks",
-        "schedule": {
-            "manual_checks": {
-                "data": {
-                    "kwargs": {
-                        "primary": true
-                    }
-                }
-            }
-        }
-    },
     "released_protected_data_files": {
         "title": "Protected data fastq or bam files not restricted",
         "group": "Audit checks",
@@ -1672,20 +1634,6 @@
                     }
                 },
                 "webdev": {
-                    "dependencies": [],
-                    "kwargs": {
-                        "primary": true
-                    }
-                }
-            }
-        }
-    },
-    "staging_deployment": {
-        "title": "Staging deployment",
-        "group": "System checks",
-        "schedule": {
-            "manual_checks": {
-                "staging": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -1903,34 +1851,6 @@
                 }
             }
         }
-    },
-    "scale_down_elasticsearch_production": {
-        "title": "Scale down production ElasticSearch Cluster",
-        "group": "System checks",
-        "schedule": {
-            "friday_autoscaling_checks": {
-                "staging": {
-                    "kwargs": {
-                        "primary": true
-                    }
-                }
-            }
-        },
-        "display": ["data", "staging"]
-    },
-    "scale_up_elasticsearch_production": {
-        "title": "Scale up production ElasticSearch Cluster",
-        "group": "System checks",
-        "schedule": {
-            "monday_autoscaling_checks": {
-                "staging": {
-                    "kwargs" : {
-                        "primary": true
-                    }
-                }
-            }
-        },
-        "display": ["data", "staging"]
     },
     "mcoolqc_status": {
         "title": "b) McoolQC",

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -97,12 +97,6 @@
                     "kwargs": {
                         "primary": true
                     }
-                },
-                "staging": {
-                    "dependencies": [],
-                    "kwargs": {
-                        "primary": true
-                    }
                 }
             }
         }
@@ -972,14 +966,6 @@
                     "kwargs": {
                         "primary": true
                     }
-                },
-                "staging": {
-                    "dependencies": [
-                        "yellow_flag_biosamples"
-                    ],
-                    "kwargs": {
-                        "primary": true
-                    }
                 }
             }
         }
@@ -1240,12 +1226,6 @@
                     }
                 },
                 "mastertest": {
-                    "dependencies": [],
-                    "kwargs": {
-                        "primary": true
-                    }
-                },
-                "staging": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -1872,12 +1852,6 @@
                     }
                 },
                 "hotseat": {
-                    "dependencies": [],
-                    "kwargs": {
-                        "primary": true
-                    }
-                },
-                "staging": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -1328,12 +1328,6 @@
                   "kwargs": {
                       "primary": true
                   }
-              },
-              "staging": {
-                  "dependencies": [],
-                  "kwargs": {
-                      "primary": true
-                  }
               }
           }
       }
@@ -1350,12 +1344,6 @@
                     }
                 },
                 "hotseat": {
-                    "dependencies": [],
-                    "kwargs": {
-                        "primary": true
-                    }
-                },
-                "staging": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -1380,12 +1368,6 @@
                     "kwargs": {
                         "primary": true
                     }
-                },
-                "staging": {
-                    "dependencies": [],
-                    "kwargs": {
-                        "primary": true
-                    }
                 }
             }
         }
@@ -1402,12 +1384,6 @@
                     }
                 },
                 "hotseat": {
-                    "dependencies": [],
-                    "kwargs": {
-                        "primary": true
-                    }
-                },
-                "staging": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -1432,12 +1408,6 @@
                     "kwargs": {
                         "primary": true
                     }
-                },
-                "staging": {
-                    "dependencies": [],
-                    "kwargs": {
-                        "primary": true
-                    }
                 }
             }
         }
@@ -1454,12 +1424,6 @@
                     }
                 },
                 "hotseat": {
-                    "dependencies": [],
-                    "kwargs": {
-                        "primary": true
-                    }
-                },
-                "staging": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true
@@ -1498,12 +1462,6 @@
                     "kwargs": {
                         "primary": true
                     }
-                },
-                "staging": {
-                    "dependencies": [],
-                    "kwargs": {
-                        "primary": true
-                    }
                 }
             }
         }
@@ -1524,12 +1482,6 @@
                     "kwargs": {
                         "primary": true
                     }
-                },
-                "staging": {
-                    "dependencies": [],
-                    "kwargs": {
-                        "primary": true
-                    }
                 }
             }
         }
@@ -1546,12 +1498,6 @@
                     }
                 },
                 "hotseat": {
-                    "dependencies": [],
-                    "kwargs": {
-                        "primary": true
-                    }
-                },
-                "staging": {
                     "dependencies": [],
                     "kwargs": {
                         "primary": true

--- a/chalicelib/check_setup.json
+++ b/chalicelib/check_setup.json
@@ -127,7 +127,10 @@
                     }
                 }
             }
-        }
+        },
+        "display": [
+            "all"
+        ]
     },
     "capture_hic_status": {
         "title": "d) Capture Hi-C",
@@ -532,7 +535,10 @@
                     }
                 }
             }
-        }
+        },
+        "display": [
+            "all"
+        ]
     },
     "check_search_urls": {
         "title": "Static Section search URLs check",
@@ -560,7 +566,10 @@
                     }
                 }
             }
-        }
+        },
+        "display": [
+            "all"
+        ]
     },
     "check_suggested_enum_values": {
         "title": "Check fields with suggested enum",
@@ -588,7 +597,10 @@
                     }
                 }
             }
-        }
+        },
+        "display": [
+            "all"
+        ]
     },
     "chia_pet_status": {
         "title": "d) ChIA-PET",
@@ -692,7 +704,10 @@
                     }
                 }
             }
-        }
+        },
+        "display": [
+            "all"
+        ]
     },
     "deploy_application_to_beanstalk": {
         "title": "Deploy Version to ElasticBeanstalk",
@@ -804,7 +819,10 @@
                     }
                 }
             }
-        }
+        },
+        "display": [
+            "all"
+        ]
     },
     "expset_opf_unique_files": {
         "title": "Experiment Sets with other processed files also present in files",
@@ -834,7 +852,10 @@
                     }
                 }
             }
-        }
+        },
+        "display": [
+            "all"
+        ]
     },
     "expset_opfsets_unique_titles": {
         "title": "Experiment Sets with missing or duplicated titles for sets of other processed files",
@@ -848,7 +869,10 @@
                     }
                 }
             }
-        }
+        },
+        "display": [
+            "all"
+        ]
     },
     "external_expsets_without_pub": {
         "title": "External experiment sets without a publication",
@@ -862,7 +886,10 @@
                     }
                 }
             }
-        }
+        },
+        "display": [
+            "all"
+        ]
     },
     "external_submission_but_missing_dbxrefs": {
         "title": "Items with external_submission but missing dbxrefs",
@@ -1569,7 +1596,7 @@
     "repsets_have_bio_reps": {
         "title": "Replicate experiment sets with replicate number issues",
         "group": "Badge checks",
-          "schedule": {
+        "schedule": {
             "morning_checks_3": {
                 "data": {
                     "dependencies": [],
@@ -1578,7 +1605,10 @@
                     }
                 }
             }
-        }
+        },
+        "display": [
+            "all"
+        ]
     },
     "rna_seq_status": {
         "title": "i) RNA-seq",
@@ -1794,7 +1824,10 @@
                     }
                 }
             }
-        }
+        },
+        "display": [
+            "all"
+        ]
     },
     "wipe_ff_build_indices": {
         "title": "Wipe FF build indices",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "2.1.1"
+version = "2.1.2"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
It seems unnecessary to run metadata-related checks on `staging`, as it shares the database with `data`. These include:
- static header checks
- badge checks
- audit checks

Additionally, some metadata-related checks that were scheduled to run on `all` environments are only needed for `data`, and not for non-production environments. This includes static headers, badges, unique titles in opf, missing publication, missing ontology term for cells, assay names, etc.

In general, it might be good to have checks available for various environments, but running them on a schedule doesn't seem always necessary. Therefore, in these cases where I removed `all`, I added `display: all`.

This PR also disables the staging deployment check, currently unused, by setting it to the manual_checks schedule.