### PR TITLE
Errored runs chk edit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Change Log
 * Edited the check for errored workflow runs to only report recent ones.
 
   * By default in the past 30 days. This can be modified using the ``days_back`` arg.
-  * Use any string different than a number to search all errored runs.
+  * Use 0 to search all errored runs.
 
 2.3.1
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ foursight
 Change Log
 ----------
 
+2.3.2
+=====
+
+* Edited the check for errored workflow runs to only report recent ones.
+
+  * By default in the past 30 days. This can be modified using the ``days_back`` arg.
+  * Use any string different than a number to search all errored runs.
 
 2.3.1
 =====

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -2535,8 +2535,7 @@ def problematic_wfrs_fdn_status(connection, **kwargs):
                         which categories to delete with action, by default Rerun is deleted
      - limit_to_uuids: comma separated uuids to be returned to be deleted, to be used when a subset of runs needs cleanup
                        should also work if a list item is provided as input
-     - days_back: (string) limit the search to recently created wfrs, up to n days ago.
-                  If 0 or any string different than an integer, search all wfrs.
+     - days_back: (string) limit the search to recently created wfrs, up to n days ago. If 0, search all wfrs.
     """
     check = CheckResult(connection, 'problematic_wfrs_fdn_status')
     my_auth = connection.ff_keys

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from dcicutils import ff_utils
 from dcicutils.s3_utils import s3Utils
 from .helpers import wfr_utils
@@ -2553,7 +2553,7 @@ def problematic_wfrs_fdn_status(connection, **kwargs):
         try:
             days_back = int(kwargs['days_back'])
             if days_back != 0:
-                from_date = datetime.strftime(datetime.now(timezone.utc) - timedelta(days=days_back), "%Y-%m-%d")
+                from_date = datetime.strftime(datetime.utcnow() - timedelta(days=days_back), "%Y-%m-%d")
                 q += '&date_created.from=' + from_date
         except (ValueError, TypeError):
             # if any other value (e.g. a string) is provided, search all wfrs

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -2525,7 +2525,7 @@ def long_running_wfrs_fdn_start(connection, **kwargs):
     return action
 
 
-@check_function(delete_categories='Rerun', limit_to_uuids="")
+@check_function(delete_categories='Rerun', limit_to_uuids="", days_back='30')
 def problematic_wfrs_fdn_status(connection, **kwargs):
     """
     Find all runs with run status error. Action will cleanup their metadata, and this action might
@@ -2535,6 +2535,8 @@ def problematic_wfrs_fdn_status(connection, **kwargs):
                         which categories to delete with action, by default Rerun is deleted
      - limit_to_uuids: comma separated uuids to be returned to be deleted, to be used when a subset of runs needs cleanup
                        should also work if a list item is provided as input
+     - days_back: (string) limit the search to recently created wfrs, up to n days ago.
+                  If 0 or any string different than an integer, search all wfrs.
     """
     check = CheckResult(connection, 'problematic_wfrs_fdn_status')
     my_auth = connection.ff_keys
@@ -2547,6 +2549,16 @@ def problematic_wfrs_fdn_status(connection, **kwargs):
     check.allow_action = False
     # find all errored runs
     q = '/search/?type=WorkflowRun&run_status=error'
+    if kwargs.get('days_back'):
+        try:
+            days_back = int(kwargs['days_back'])
+            if days_back != 0:
+                from_date = datetime.strftime(datetime.now(timezone.utc) - timedelta(days=days_back), "%Y-%m-%d")
+                q += '&date_created.from=' + from_date
+        except (ValueError, TypeError):
+            # if any other value (e.g. a string) is provided, search all wfrs
+            pass
+
     errored_wfrs = ff_utils.search_metadata(q, my_auth)
     # if a comma separated list of uuids is given, limit the result to them
     uuids = str(kwargs.get('limit_to_uuids'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "2.3.2"
+version = "2.3.3"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
* Edited the check for errored workflow runs to only report recent ones.
  * By default in the past 30 days. This can be modified using the ``days_back`` arg.
  * Use any string different than a number to search all errored runs.
