### PR TITLE
limit beddb reruns for reference files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ foursight
 Change Log
 ----------
 
+3.3.1
+=====
+
+`PR 522: limit beddb reruns for reference files <https://github.com/4dn-dcic/foursight/pull/522>`_
+
+* Bug fix: prevent automatic execution of bedtobeddb workflow on FileReference
+  items when at least 2 previous runs exist.
+
 3.3.0
 =====
 * Changes related editing user projects/institutions.
@@ -15,7 +23,7 @@ Change Log
 3.2.1
 =====
 
-`PR 519: Bug fix ont upd check https://github.com/4dn-dcic/foursight/pull/519>`_
+`PR 519: Bug fix ont upd check <https://github.com/4dn-dcic/foursight/pull/519>`_
 
 * bug fix for check_for_ontology_updates - request more of the file header to get version info
 

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -649,9 +649,9 @@ def bed2beddb_status(connection, **kwargs):
     previous = []
     for a_file in [f for f in res_all]:
         if a_file['@type'][0] in ['FileReference']:
-            failed_runs_query = ("/search/?type=WorkflowRunAwsem&awsem_app_name=bedtobeddb"
-                                 f"&input_files.value.accession={a_file['accession']}")
-            n_runs = len(ff_utils.search_metadata(failed_runs_query + '&field=@id', key=my_auth))
+            previous_runs_query = ("/search/?type=WorkflowRunAwsem&awsem_app_name=bedtobeddb"
+                                   f"&input_files.value.accession={a_file['accession']}")
+            n_runs = len(ff_utils.search_metadata(previous_runs_query + '&field=@id', key=my_auth))
             if n_runs > 1:
                 # two or more previous runs: do not start a new one
                 # note that these could be running, completed, failed, or any other run status

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -641,6 +641,10 @@ def bed2beddb_status(connection, **kwargs):
             missing.append(a_file['accession'])
     res_all = [i for i in res_all if i.get('genome_assembly')]
 
+    if not res_all:
+        check.summary = 'All Good!'
+        return check
+
     # check for previous runs if file is FileReference (as this type does not track wfr inputs)
     previous = []
     for a_file in [f for f in res_all]:
@@ -654,9 +658,6 @@ def bed2beddb_status(connection, **kwargs):
                 previous.append(a_file)
                 res_all.remove(a_file)
 
-    if not res_all:
-        check.summary = 'All Good!'
-        return check
     check = wfr_utils.check_runs_without_output(res_all, check, 'bedtobeddb', my_auth, start)
     if missing:
         check.full_output['missing_assembly'] = missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "3.3.0"
+version = "3.3.1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Pipelines normally do not start automatically in case (2 or more) previous runs are detected. This mechanism does not work for FileReference items, because they do not have workflow run inputs. Since bed2beddb pipeline can run also on FileReference items, this PR introduces a different way to check for pre-existing runs of the same pipeline on the same file.