### PR TITLE
new check to automate patching of FOF-CT static section for chromatin datasets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ foursight
 Change Log
 ----------
 
+3.4.3
+=====
+* Added a new check for automate patching of FOF-CT static section for chromatin tracing datasets
+
 3.4.2
 =====
 * Version changes related to foursight-core changes for SSL certificate and Portal access key checking.

--- a/chalicelib_fourfront/check_setup.json
+++ b/chalicelib_fourfront/check_setup.json
@@ -1500,6 +1500,26 @@
             }
         }
     },
+    "prepare_static_headers_Chromatin_Tracing": {
+        "title": "Chromatin Tracing",
+        "group": "Static headers checks",
+        "schedule": {
+            "morning_checks_3": {
+                "data": {
+                    "dependencies": [],
+                    "kwargs": {
+                        "primary": true
+                    }
+                },
+                "hotseat": {
+                    "dependencies": [],
+                    "kwargs": {
+                        "primary": true
+                    }
+                }
+            }
+        }
+    },    
     "problematic_wfrs_fdn_status": {
         "title": "x) Errored Runs",
         "group": "Pipeline checks",

--- a/chalicelib_fourfront/checks/header_checks.py
+++ b/chalicelib_fourfront/checks/header_checks.py
@@ -312,3 +312,23 @@ def patch_static_headers_DNase_HiC(connection, **kwargs):
     # get latest results from prepare_static_headers
     patch_items_with_headers(connection, action, kwargs)
     return action
+
+#Chromatin Tracing
+@check_function()
+def prepare_static_headers_Chromatin_Tracing(connection, **kwargs):
+     check = CheckResult(connection, 'prepare_static_headers_Chromatin_Tracing')
+     add_search = '/search/?experiments_in_set.experiment_type.display_title=multiplexed+FISH&experiments_in_set.experiment_type.display_title=RNA+FISH&experiments_in_set.experiment_type.display_title=SPT&experiments_in_set.experiment_type.display_title=OptoDroplet&experiments_in_set.experiment_type.display_title=DNA+FISH&experiments_in_set.experiment_type.display_title=Immunofluorescence&experiments_in_set.experiment_type.display_title=Electron+Tomography&experimentset_type=replicate&type=ExperimentSetReplicate'
+     remove_search = '/search/?type=ExperimentSetReplicate&experimentset_type=replicate&experiments_in_set.experiment_type.display_title%21=multiplexed+FISH&experiments_in_set.experiment_type.display_title%21=RNA+FISH&experiments_in_set.experiment_type.display_title%21=SPT&experiments_in_set.experiment_type.display_title%21=OptoDroplet&experiments_in_set.experiment_type.display_title%21=DNA+FISH&experiments_in_set.experiment_type.display_title%21=Immunofluorescence&experiments_in_set.experiment_type.display_title%21=Electron+Tomography&experimentset_type=replicate&type=ExperimentSetReplicate'
+     header_at_id = '/static-sections/a09a2833-b56b-4e81-8eff-bb8ae6aaa596/'
+     check.action = 'patch_static_headers_Chromatin_Tracing'
+     find_items_for_header_processing(connection, check, header_at_id,
+                                      add_search, remove_search)
+     return check
+
+
+@action_function()
+def patch_static_headers_Chromatin_Tracing(connection, **kwargs):
+     action = ActionResult(connection, 'patch_static_headers_Chromatin_Tracing')
+     # get latest results from prepare_static_headers
+     patch_items_with_headers(connection, action, kwargs)
+     return action

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "3.4.2"
+version = "3.4.3"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
As we don't have a combined "chromatin tracing" experiment type, I added the different experiment sets (Multiplexed FISH, RNA FISH, SPT, OptoDroplet, DNA FISH, Immunofluorescence, Electron Tomography) under the same search. Let me know if this works or I can create the same check for different experiment types separately. 
