### PR TITLE
Add new audit check for chip-seq biofeatures missing needed tag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ foursight
 Change Log
 ----------
 
+3.4.9
+=====
+
+`PR 535: Add new audit check for ChIP-seq target tags <https://github.com/4dn-dcic/foursight/pull/535>`_
+
+* New check that makes sure that BioFeatures linked to ChIP-seq experiments as targets have the correct tag added
+
+3.4.8
+=====
+David???
+
 3.4.7
 =====
 * Fix to prepare_static_headers_Chromatin_Tracing in checks/header_checks.py from fix_sh_ct_dec branch.

--- a/chalicelib_fourfront/check_setup.json
+++ b/chalicelib_fourfront/check_setup.json
@@ -356,6 +356,20 @@
             }
         }
     },
+    "chipseq_target_missing_tag": {
+        "title": "ChIP-seq target BioFeature missing tag for wfr",
+        "group": "Audit checks",
+        "schedule": {
+            "morning_checks_1": {
+                "data": {
+                    "dependencies": [],
+                    "kwargs": {
+                        "primary": true
+                    }
+                }
+            }
+        }
+    },
     "check_for_ontology_updates": {
         "title": "Check for Ontology Updates",
         "group": "Metadata checks",

--- a/chalicelib_fourfront/checks/audit_checks.py
+++ b/chalicelib_fourfront/checks/audit_checks.py
@@ -1227,7 +1227,7 @@ def chipseq_target_missing_tag(connection, **kwargs):
             check.description = "Exeption generatated\n{}".format(e)
             return check
         bf_tags = bfeat.get('tags', [])
-        if not any(i in ['histone', 'dna binding'] for i in bf_tags):
+        if not any(i in ['histone', 'dna-binding'] for i in bf_tags):
             bf_missing_tag.setdefault(bfeat.get('uuid'), []).append(exp.get('@id'))
     if bf_missing_tag:
         check.brief_output = {k: len(v) for k,v in bf_missing_tag.items()}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "3.4.6"
+version = "3.4.8b"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
A new audit check to make sure that any target BioFeature of a ChIP-seq experiment has the appropriate tag (histone, dna-binding) that is used to determine the parameters used for running the pipeline.