### PR TITLE
modify checks that check rate limit to provide informative output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Change Log
 3.5.2
 =====
 
-`PR : Update checks that check for number of runs - rate limits output <https://github.com/4dn-dcic/foursight/pull/>`_
+`PR 538: Update checks that check for number of runs - rate limits output <https://github.com/4dn-dcic/foursight/pull/538>`_
 
 * Adding info to brief output and WARN if the function that checks the number of runs over the past 6 hours indicates not to start new runs.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ foursight
 Change Log
 ----------
 
+3.5.2
+=====
+
+`PR : Update checks that check for number of runs - rate limits output <https://github.com/4dn-dcic/foursight/pull/>`_
+
+* Adding info to brief output and WARN if the function that checks the number of runs over the past 6 hours indicates not to start new runs.
+
 3.5.1
 =====
 

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -114,6 +114,8 @@ def md5run_status(connection, **kwargs):
     # check number of total workflow runs in the past 6h
     check, n_runs_available = wfr_utils.limit_number_of_runs(check, my_auth)
     if n_runs_available == 0:
+        check.brief_output.append('Runs are limited due to docker pull rate limit')
+        check.status = 'WARN'
         return check
 
     # Build the query
@@ -319,6 +321,8 @@ def fastqc_status(connection, **kwargs):
     # check number of total workflow runs in the past 6h
     check, n_runs_available = wfr_utils.limit_number_of_runs(check, my_auth)
     if n_runs_available == 0:
+        check.brief_output.append('Runs are limited due to docker pull rate limit')
+        check.status = 'WARN'
         return check
 
     # Build the query (skip to be uploaded by workflow)
@@ -2088,6 +2092,8 @@ def fastq_first_line_status(connection, **kwargs):
     # check number of total workflow runs in the past 6h
     check, n_runs_available = wfr_utils.limit_number_of_runs(check, my_auth)
     if n_runs_available == 0:
+        check.brief_output.append('Runs are limited due to docker pull rate limit')
+        check.status = 'WARN'
         return check
 
     query = ('/search/?status=uploaded&status=pre-release&status=released+to+project&status=released'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "3.5.1"
+version = "3.5.2"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Add output if too many WFRs on fastq are running so you know why they aren't launching.