### PR TITLE
fix small bug in repset badge chk

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,10 +7,16 @@ foursight
 Change Log
 ----------
 
+3.6.1
+=====
+
+
+
+* Fixed a bug in the replicate set consistency badge check 
+
 3.6.0
 =====
 * Changes (to foursight-core) to the access key check; making sure the action does not run every single day.
-
 
 3.5.2
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Change Log
 3.6.1
 =====
 
-
+`PR 539: badge bug fix <https://github.com/4dn-dcic/foursight/pull/539>`_
 
 * Fixed a bug in the replicate set consistency badge check 
 

--- a/chalicelib_fourfront/checks/badge_checks.py
+++ b/chalicelib_fourfront/checks/badge_checks.py
@@ -706,7 +706,7 @@ def consistent_replicate_info(connection, **kwargs):
             audit_key = REV_KEY if repset['status'] in REV else RELEASED_KEY
             results[repset['@id']] = {'status': audit_key, 'lab': lab, 'info': text}
             if audit_key == REV_KEY:
-                check.brief_output[audit_key][lab] = check.brief_output[audit_key].setdefault(lab, []).append(text)
+                check.brief_output[audit_key].setdefault(lab, []).append(text)
             if repset['status'] not in REV:
                 compare[repset['@id']] = msgs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "3.6.0"
+version = "3.6.1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Small bug fix - odd syntax on I guess rarely hit clause was causing an Exception in the badge check for replicate sets consistency.  