### PR TITLE
rewrite sync_users_oh to remove pandas and numpy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ foursight
 Change Log
 ----------
 
+3.6.4
+=====
+
+`PR 542: rewrite sync_users_oh to remove pandas <https://github.com/4dn-dcic/foursight/pull/542>`_
+
+* remove pandas to reduce package size
+
+
 3.6.3
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Change Log
 3.6.4
 =====
 
-`PR 542: rewrite sync_users_oh to remove pandas and numpy <https://github.com/4dn-dcic/foursight/pull/542>`_
+`PR 543: rewrite sync_users_oh to remove pandas and numpy <https://github.com/4dn-dcic/foursight/pull/543>`_
 
 * remove pandas and numpy to reduce package size
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,9 +10,9 @@ Change Log
 3.6.4
 =====
 
-`PR 542: rewrite sync_users_oh to remove pandas <https://github.com/4dn-dcic/foursight/pull/542>`_
+`PR 542: rewrite sync_users_oh to remove pandas and numpy <https://github.com/4dn-dcic/foursight/pull/542>`_
 
-* remove pandas to reduce package size
+* remove pandas and numpy to reduce package size
 
 
 3.6.3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,13 +7,14 @@ foursight
 Change Log
 ----------
 
-3.6.4
+
+3.7.0
 =====
 
 `PR 543: rewrite sync_users_oh to remove pandas and numpy <https://github.com/4dn-dcic/foursight/pull/543>`_
 
-* remove pandas and numpy to reduce package size
-
+* Removed dependency on pandas by refactoring code in wrangler_checks.py
+  to use new convert_table_to_ordered_dict function in check_utils.py.
 
 3.6.3
 =====

--- a/chalicelib_fourfront/checks/check_utils.py
+++ b/chalicelib_fourfront/checks/check_utils.py
@@ -1,0 +1,31 @@
+from collections import OrderedDict
+
+# Created (August 2023) to remove dependency on pandas package in wrangler_checks,
+# with ultimate goal of removing pandas (and numpy on which it depends) from Foursight
+# package which had grown too large (more than 50MB) for AWS Lambda (doing this should
+# reduce Foursight package size by more than 20MB). TODO: Maybe move this to dcicutils.
+def convert_table_to_ordered_dict(table: list) -> OrderedDict:
+    """
+    Given a 2-dimensional array ``table`` which is assumed to have a 0th row that represents the
+    column header names for remaining rows in the table, returns a list of ordered dictionaries
+    representing the given table rows, where each ordered dictionary contains properties for
+    each of the table header column names with values being set to the corresponding values
+    for the column from the row. For example, given a table like this:
+
+        [ ['Name',   'Age', 'Location'     ],
+          ['Alice',   25,   'New York'     ],
+          ['Bob',     30,   'London'       ],
+          ['Charlie', 28,   'San Francisco'] ]
+
+     This will be returned:
+
+        [ OrderedDict([('Name', 'Alice'  ), ('Age', 25), ('Location', 'New York'     )]),
+          OrderedDict([('Name', 'Bob'    ), ('Age', 30), ('Location', 'London'       )]),
+          OrderedDict([('Name', 'Charlie'), ('Age', 28), ('Location', 'San Francisco')]) ]
+
+    """
+    header = table[0]
+    rows = table[1:]
+    # This was originally done using the pandas packages like this:
+    # pandas.DataFrame(rows, columns=header).to_dict(orient='records', into=OrderedDict)
+    return [OrderedDict(zip(header, row)) for row in rows]

--- a/chalicelib_fourfront/checks/wrangler_checks.py
+++ b/chalicelib_fourfront/checks/wrangler_checks.py
@@ -13,6 +13,7 @@ from .helpers import wrangler_utils
 from collections import Counter
 from oauth2client.service_account import ServiceAccountCredentials
 import gspread
+from .check_utils import convert_table_to_ordered_dict
 from collections import OrderedDict
 import uuid
 
@@ -2645,7 +2646,7 @@ def sync_users_oh_status(connection, **kwargs):
     worksheet = get_oh_google_sheet()
     table = worksheet.get_all_values()
     # Convert table data into an ordered dictionary
-    user_list = [OrderedDict(zip(table[0],row)) for row in table[1:]]
+    user_list = convert_table_to_ordered_dict(table)
     # all dcic users in the list
     all_dcic_uuids = [i['DCIC UUID'] for i in user_list if i.get('DCIC UUID')]
 
@@ -2865,7 +2866,7 @@ def sync_users_oh_start(connection, **kwargs):
     worksheet = get_oh_google_sheet()
     table = worksheet.get_all_values()
     # Convert table data into an ordered dictionary
-    user_list = [OrderedDict(zip(table[0],row)) for row in table[1:]]
+    user_list = convert_table_to_ordered_dict(table)
     # generate records to write
     gs_write = []
 

--- a/chalicelib_fourfront/checks/wrangler_checks.py
+++ b/chalicelib_fourfront/checks/wrangler_checks.py
@@ -13,7 +13,6 @@ from .helpers import wrangler_utils
 from collections import Counter
 from oauth2client.service_account import ServiceAccountCredentials
 import gspread
-import pandas as pd
 from collections import OrderedDict
 import uuid
 
@@ -2646,8 +2645,7 @@ def sync_users_oh_status(connection, **kwargs):
     worksheet = get_oh_google_sheet()
     table = worksheet.get_all_values()
     # Convert table data into an ordered dictionary
-    df = pd.DataFrame(table[1:], columns=table[0])
-    user_list = df.to_dict(orient='records', into=OrderedDict)
+    user_list = [OrderedDict(zip(table[0],row)) for row in table[1:]]
     # all dcic users in the list
     all_dcic_uuids = [i['DCIC UUID'] for i in user_list if i.get('DCIC UUID')]
 
@@ -2867,8 +2865,7 @@ def sync_users_oh_start(connection, **kwargs):
     worksheet = get_oh_google_sheet()
     table = worksheet.get_all_values()
     # Convert table data into an ordered dictionary
-    df = pd.DataFrame(table[1:], columns=table[0])
-    user_list = df.to_dict(orient='records', into=OrderedDict)
+    user_list = [OrderedDict(zip(table[0],row)) for row in table[1:]]
     # generate records to write
     gs_write = []
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1131,47 +1131,6 @@ files = [
 ]
 
 [[package]]
-name = "numpy"
-version = "1.21.6"
-description = "NumPy is the fundamental package for array computing with Python."
-category = "main"
-optional = false
-python-versions = ">=3.7,<3.11"
-files = [
-    {file = "numpy-1.21.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8737609c3bbdd48e380d463134a35ffad3b22dc56295eff6f79fd85bd0eeeb25"},
-    {file = "numpy-1.21.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:fdffbfb6832cd0b300995a2b08b8f6fa9f6e856d562800fea9182316d99c4e8e"},
-    {file = "numpy-1.21.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3820724272f9913b597ccd13a467cc492a0da6b05df26ea09e78b171a0bb9da6"},
-    {file = "numpy-1.21.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f17e562de9edf691a42ddb1eb4a5541c20dd3f9e65b09ded2beb0799c0cf29bb"},
-    {file = "numpy-1.21.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f30427731561ce75d7048ac254dbe47a2ba576229250fb60f0fb74db96501a1"},
-    {file = "numpy-1.21.6-cp310-cp310-win32.whl", hash = "sha256:d4bf4d43077db55589ffc9009c0ba0a94fa4908b9586d6ccce2e0b164c86303c"},
-    {file = "numpy-1.21.6-cp310-cp310-win_amd64.whl", hash = "sha256:d136337ae3cc69aa5e447e78d8e1514be8c3ec9b54264e680cf0b4bd9011574f"},
-    {file = "numpy-1.21.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6aaf96c7f8cebc220cdfc03f1d5a31952f027dda050e5a703a0d1c396075e3e7"},
-    {file = "numpy-1.21.6-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:67c261d6c0a9981820c3a149d255a76918278a6b03b6a036800359aba1256d46"},
-    {file = "numpy-1.21.6-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a6be4cb0ef3b8c9250c19cc122267263093eee7edd4e3fa75395dfda8c17a8e2"},
-    {file = "numpy-1.21.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7c4068a8c44014b2d55f3c3f574c376b2494ca9cc73d2f1bd692382b6dffe3db"},
-    {file = "numpy-1.21.6-cp37-cp37m-win32.whl", hash = "sha256:7c7e5fa88d9ff656e067876e4736379cc962d185d5cd808014a8a928d529ef4e"},
-    {file = "numpy-1.21.6-cp37-cp37m-win_amd64.whl", hash = "sha256:bcb238c9c96c00d3085b264e5c1a1207672577b93fa666c3b14a45240b14123a"},
-    {file = "numpy-1.21.6-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:82691fda7c3f77c90e62da69ae60b5ac08e87e775b09813559f8901a88266552"},
-    {file = "numpy-1.21.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:643843bcc1c50526b3a71cd2ee561cf0d8773f062c8cbaf9ffac9fdf573f83ab"},
-    {file = "numpy-1.21.6-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:357768c2e4451ac241465157a3e929b265dfac85d9214074985b1786244f2ef3"},
-    {file = "numpy-1.21.6-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9f411b2c3f3d76bba0865b35a425157c5dcf54937f82bbeb3d3c180789dd66a6"},
-    {file = "numpy-1.21.6-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4aa48afdce4660b0076a00d80afa54e8a97cd49f457d68a4342d188a09451c1a"},
-    {file = "numpy-1.21.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d6a96eef20f639e6a97d23e57dd0c1b1069a7b4fd7027482a4c5c451cd7732f4"},
-    {file = "numpy-1.21.6-cp38-cp38-win32.whl", hash = "sha256:5c3c8def4230e1b959671eb959083661b4a0d2e9af93ee339c7dada6759a9470"},
-    {file = "numpy-1.21.6-cp38-cp38-win_amd64.whl", hash = "sha256:bf2ec4b75d0e9356edea834d1de42b31fe11f726a81dfb2c2112bc1eaa508fcf"},
-    {file = "numpy-1.21.6-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:4391bd07606be175aafd267ef9bea87cf1b8210c787666ce82073b05f202add1"},
-    {file = "numpy-1.21.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:67f21981ba2f9d7ba9ade60c9e8cbaa8cf8e9ae51673934480e45cf55e953673"},
-    {file = "numpy-1.21.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ee5ec40fdd06d62fe5d4084bef4fd50fd4bb6bfd2bf519365f569dc470163ab0"},
-    {file = "numpy-1.21.6-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1dbe1c91269f880e364526649a52eff93ac30035507ae980d2fed33aaee633ac"},
-    {file = "numpy-1.21.6-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d9caa9d5e682102453d96a0ee10c7241b72859b01a941a397fd965f23b3e016b"},
-    {file = "numpy-1.21.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58459d3bad03343ac4b1b42ed14d571b8743dc80ccbf27444f266729df1d6f5b"},
-    {file = "numpy-1.21.6-cp39-cp39-win32.whl", hash = "sha256:7f5ae4f304257569ef3b948810816bc87c9146e8c446053539947eedeaa32786"},
-    {file = "numpy-1.21.6-cp39-cp39-win_amd64.whl", hash = "sha256:e31f0bb5928b793169b87e3d1e070f2342b22d5245c755e2b81caa29756246c3"},
-    {file = "numpy-1.21.6-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:dd1c8f6bd65d07d3810b90d02eba7997e32abbdf1277a481d698969e921a3be0"},
-    {file = "numpy-1.21.6.zip", hash = "sha256:ecb55251139706669fdec2ff073c98ef8e9a84473e51e716211b41aa0f18e656"},
-]
-
-[[package]]
 name = "oauth2client"
 version = "4.1.3"
 description = "OAuth 2.0 client library"
@@ -1243,53 +1202,6 @@ files = [
     {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
     {file = "packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
 ]
-
-[[package]]
-name = "pandas"
-version = "1.3.5"
-description = "Powerful data structures for data analysis, time series, and statistics"
-category = "main"
-optional = false
-python-versions = ">=3.7.1"
-files = [
-    {file = "pandas-1.3.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:62d5b5ce965bae78f12c1c0df0d387899dd4211ec0bdc52822373f13a3a022b9"},
-    {file = "pandas-1.3.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:adfeb11be2d54f275142c8ba9bf67acee771b7186a5745249c7d5a06c670136b"},
-    {file = "pandas-1.3.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:60a8c055d58873ad81cae290d974d13dd479b82cbb975c3e1fa2cf1920715296"},
-    {file = "pandas-1.3.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd541ab09e1f80a2a1760032d665f6e032d8e44055d602d65eeea6e6e85498cb"},
-    {file = "pandas-1.3.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2651d75b9a167cc8cc572cf787ab512d16e316ae00ba81874b560586fa1325e0"},
-    {file = "pandas-1.3.5-cp310-cp310-win_amd64.whl", hash = "sha256:aaf183a615ad790801fa3cf2fa450e5b6d23a54684fe386f7e3208f8b9bfbef6"},
-    {file = "pandas-1.3.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:344295811e67f8200de2390093aeb3c8309f5648951b684d8db7eee7d1c81fb7"},
-    {file = "pandas-1.3.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:552020bf83b7f9033b57cbae65589c01e7ef1544416122da0c79140c93288f56"},
-    {file = "pandas-1.3.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5cce0c6bbeb266b0e39e35176ee615ce3585233092f685b6a82362523e59e5b4"},
-    {file = "pandas-1.3.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d28a3c65463fd0d0ba8bbb7696b23073efee0510783340a44b08f5e96ffce0c"},
-    {file = "pandas-1.3.5-cp37-cp37m-win32.whl", hash = "sha256:a62949c626dd0ef7de11de34b44c6475db76995c2064e2d99c6498c3dba7fe58"},
-    {file = "pandas-1.3.5-cp37-cp37m-win_amd64.whl", hash = "sha256:8025750767e138320b15ca16d70d5cdc1886e8f9cc56652d89735c016cd8aea6"},
-    {file = "pandas-1.3.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fe95bae4e2d579812865db2212bb733144e34d0c6785c0685329e5b60fcb85dd"},
-    {file = "pandas-1.3.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f261553a1e9c65b7a310302b9dbac31cf0049a51695c14ebe04e4bfd4a96f02"},
-    {file = "pandas-1.3.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b6dbec5f3e6d5dc80dcfee250e0a2a652b3f28663492f7dab9a24416a48ac39"},
-    {file = "pandas-1.3.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d3bc49af96cd6285030a64779de5b3688633a07eb75c124b0747134a63f4c05f"},
-    {file = "pandas-1.3.5-cp38-cp38-win32.whl", hash = "sha256:b6b87b2fb39e6383ca28e2829cddef1d9fc9e27e55ad91ca9c435572cdba51bf"},
-    {file = "pandas-1.3.5-cp38-cp38-win_amd64.whl", hash = "sha256:a395692046fd8ce1edb4c6295c35184ae0c2bbe787ecbe384251da609e27edcb"},
-    {file = "pandas-1.3.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bd971a3f08b745a75a86c00b97f3007c2ea175951286cdda6abe543e687e5f2f"},
-    {file = "pandas-1.3.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37f06b59e5bc05711a518aa10beaec10942188dccb48918bb5ae602ccbc9f1a0"},
-    {file = "pandas-1.3.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c21778a688d3712d35710501f8001cdbf96eb70a7c587a3d5613573299fdca6"},
-    {file = "pandas-1.3.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3345343206546545bc26a05b4602b6a24385b5ec7c75cb6059599e3d56831da2"},
-    {file = "pandas-1.3.5-cp39-cp39-win32.whl", hash = "sha256:c69406a2808ba6cf580c2255bcf260b3f214d2664a3a4197d0e640f573b46fd3"},
-    {file = "pandas-1.3.5-cp39-cp39-win_amd64.whl", hash = "sha256:32e1a26d5ade11b547721a72f9bfc4bd113396947606e00d5b4a5b79b3dcb006"},
-    {file = "pandas-1.3.5.tar.gz", hash = "sha256:1e4285f5de1012de20ca46b188ccf33521bff61ba5c5ebd78b4fb28e5416a9f1"},
-]
-
-[package.dependencies]
-numpy = [
-    {version = ">=1.17.3", markers = "platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
-    {version = ">=1.19.2", markers = "platform_machine == \"aarch64\" and python_version < \"3.10\""},
-    {version = ">=1.20.0", markers = "platform_machine == \"arm64\" and python_version < \"3.10\""},
-]
-python-dateutil = ">=2.7.3"
-pytz = ">=2017.3"
-
-[package.extras]
-test = ["hypothesis (>=3.58)", "pytest (>=6.0)", "pytest-xdist"]
 
 [[package]]
 name = "pip"
@@ -2096,4 +2008,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "d7351bf401a987d6ff60949a0270e1cc83cf1d0aec2cce09a0e2d63e181c68b7"
+content-hash = "0b82c8751e6bdfe49d4abbf806f656e25395c34f8d771406fe09a11da087a40c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "3.6.4"
+version = "3.7.0"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "3.6.3"
+version = "3.6.4"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"
@@ -30,7 +30,6 @@ foursight-core = "4.4.0"
 pytest = "5.1.2"
 gspread = ">=3.6.0"
 oauth2client = ">=4.1.3"
-pandas = ">=1.1.4"
 
 [tool.poetry.dev-dependencies]
 chalice = "^1.26.0"

--- a/tests/test_check_utils.py
+++ b/tests/test_check_utils.py
@@ -1,4 +1,8 @@
 from conftest import *
+from collections import OrderedDict
+from chalicelib_fourfront.checks.check_utils import (
+    convert_table_to_ordered_dict
+)
 
 
 class TestCheckUtils():
@@ -276,3 +280,14 @@ class TestCheckUtils():
         assert placeholder['name'] == 'test_check'
         assert placeholder['status'] == 'PASS'
         assert placeholder['description'] == 'If queued, this check will run with default arguments'
+
+    def test_convert_table_to_ordered_dict(self):
+        table = [['Name', 'Age', 'Location'],
+                 ['Alice', 25, 'Lviv'],
+                 ['Bob', 30, 'London'],
+                 ['Chet', 28, 'Moscow']]
+        expected_result = [
+            OrderedDict([('Name', 'Alice'), ('Age', 25), ('Location', 'Lviv')]),
+            OrderedDict([('Name', 'Bob'), ('Age', 30), ('Location', 'London')]),
+            OrderedDict([('Name', 'Chet'), ('Age', 28), ('Location', 'Moscow')])]
+        assert convert_table_to_ordered_dict(table) == expected_result


### PR DESCRIPTION
Modified `sync_users_oh_check` and `sync_users_oh_status` to remove dependency on pandas (and also numpy). Updated lock file using `poetry update pandas`.