### PR TITLE
md5_status check update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ foursight
 Change Log
 ----------
 
+4.1.1
+=====
+
+* Fix for md5_status check to allow checking all file metadata but only kickoff limited number of runs if too many files
+
 4.1.0
 =====
 

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -214,7 +214,7 @@ def md5run_status(connection, **kwargs):
         check.status = 'WARN'
     if not_switched_status:
         check.allow_action = True
-        check.summary += 'Some files have wrong status and will re-run to update\n'
+        summary += 'Some files have wrong status and will re-run to update\n'
         msg = str(len(not_switched_status)) + ' file(s) have wrong status with a successful run to start'
         check.brief_output.append(msg)
         check.full_output['files_with_run_and_wrong_status_to_start'] = not_switched_status

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -294,7 +294,7 @@ def md5run_start(connection, **kwargs):
     targets = []
     if kwargs.get('start_missing'):
         # get uploading files from md5run_status
-        targets.extend(md5run_check_result.get('files_without_md5run', []))
+        targets.extend(md5run_check_result.get('files_without_md5run_to_start', []))
         # get uploaded files from md5run_uploaded_files
         targets.extend(md5run_check_result.get('uploaded_without_md5run', []))
     if kwargs.get('start_not_switched'):

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -132,7 +132,7 @@ def md5run_status(connection, **kwargs):
     if lab:
         query += '&lab.display_title=' + lab
     # The search
-    res = ff_utils.search_metadata(query, key=my_auth)
+    res = ff_utils.search_metadata(query, key=my_auth, is_generator=True)
     if not res:
         check.summary = 'All Good!'
         return check

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -133,7 +133,7 @@ def md5run_status(connection, **kwargs):
         query += '&lab.display_title=' + lab
     # The search
     res = ff_utils.search_metadata(query, key=my_auth, is_generator=True)
-    if not res:
+    if not any(res):
         check.summary = 'All Good!'
         return check
     # if there are files, make sure they are not on s3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "4.1.0"
+version = "4.1.1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
This check has a throttle that limits the number of runs of these workflows that can be kicked off by the action to avoid going beyond the docker-hub pull limit of 200/6h.

Previously the way this was written was that the list of files checked was obtained by grabbing first n items from the search response where n is determined as (pull limit - the number of workflow_runs) created in the past 6 hours.  However, we just ran into the case where 1 submitter uploaded 100+ files (and the md5 was kicked for some but not all of them - due to the pull limit throttle ) and in the meantime before n was high enough to finish all the runs a different submitter uploaded metadata for ~1000 files but did not upload the actual files.  This meant that the same n files from the beginning of the list (those most recently submitted) got processed by the check and since they are still not uploaded the check is futilely spinning until they are.

This PR allows all the file items in the search_metadata response to be checked and how the appropriate number to run to avoid hitting the limit is determined (within the iterated results rather than limiting the number of items that are input to the iteration.

NOTE: that there is an (probably related) issue in that the check does not look to be triggered at all even though it is scheduled.  We thought that updating the docker that was pointed to in the Workflow Item had fixed this but the check still doesn't seem to be running as far as Will can tell.  However, the check appeared to run fine locally both before and after this update so I have no way to know if this change will resolve that.  I did also switch search_metadata to return as a generator if maybe there is a memory issue.