### PR TITLE
New upd doppel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ foursight
 Change Log
 ----------
 
+4.2.1
+=====
+
+* a refactor of the refactor to make more efficient
+* will only check all combinations for similarity if the 'find_similar' parameter = True
+
+`PR 559: another refactor doppelganger check <https://github.com/4dn-dcic/foursight/pull/559>`_
+
 4.2.0
 =====
 

--- a/chalicelib_fourfront/checks/wrangler_checks.py
+++ b/chalicelib_fourfront/checks/wrangler_checks.py
@@ -1242,7 +1242,6 @@ def users_with_doppelganger(connection, **kwargs):
             if a_user.get(f):
                 user_mails.append(a_user[f].lower())
         a_user['all_mails'] = list(set(user_mails))
-
     cases = []
     iffy_cases = []
     name_by_users = {}
@@ -1250,12 +1249,11 @@ def users_with_doppelganger(connection, **kwargs):
     for a_user in all_users:
         name = a_user.get('display_title').lower()
         name_by_users.setdefault(name, []).append(a_user)
-        for email in a_user.get('all_emails', []):
+        for email in a_user.get('all_mails', []):
             email_by_users.setdefault(email, []).append(a_user)
 
     for e, u in email_by_users.items():
         if len(u) > 1:
-            import pdb; pdb.set_trace()
             combs = itertools.combinations(u, 2)
             for comb in combs:
                 us1 = comb[0]
@@ -1361,8 +1359,8 @@ def users_with_doppelganger(connection, **kwargs):
         check.brief_output = []
 
     # are the ignored ones getting out of control N.B. Don't think this needs to fail
-    if len(ignored_cases) > 100:
-        fail_msg = '\nNOTE: Number of ignored cases is very high, time to resolve'
+    if len(ignored_cases) > 300:
+        fail_msg = '\nNOTE: Number of ignored cases is very high'
         check.brief_output.append(fail_msg)
         check.status = 'WARN'
     return check

--- a/chalicelib_fourfront/checks/wrangler_checks.py
+++ b/chalicelib_fourfront/checks/wrangler_checks.py
@@ -1243,28 +1243,41 @@ def users_with_doppelganger(connection, **kwargs):
                 user_mails.append(a_user[f].lower())
         a_user['all_mails'] = list(set(user_mails))
 
-    # go through each combination
-    combs = itertools.combinations(all_users, 2)
     cases = []
     iffy_cases = []
-    for comb in combs:
-        us1 = comb[0]
-        us2 = comb[1]
-        # is there a common email between the 2 users
-        common_mail = list(set(us1['all_mails']) & set(us2['all_mails']))
-        if common_mail:
-            msg = '{} and {} share mail(s) {}'.format(
+    name_by_users = {}
+    email_by_users = {}
+    for a_user in all_users:
+        name = a_user.get('display_title').lower()
+        name_by_users.setdefault(name, []).append(a_user)
+        for email in a_user.get('all_emails', []):
+            email_by_users.setdefault(email, []).append(a_user)
+
+    for e, u in email_by_users.items():
+        if len(u) > 1:
+            import pdb; pdb.set_trace()
+            combs = itertools.combinations(u, 2)
+            for comb in combs:
+                us1 = comb[0]
+                us2 = comb[1]
+                msg = '{} and {} share mail(s) {}'.format(
                 us1['display_title'],
                 us2['display_title'],
-                str(common_mail))
+                e)
             log = {'user1': [us1['display_title'], us1['@id'], us1['email']],
                    'user2': [us2['display_title'], us2['@id'], us2['email']],
-                   'log': 'has shared email(s) {}'.format(str(common_mail)),
+                   'log': 'has shared email(s) {}'.format(e),
                    'brief': msg}
             cases.append(log)
-        # if not, compare names
-        elif us1['display_title'].lower() == us2['display_title'].lower():
-            msg = '{} and {} are the same'.format(
+            
+    for u in name_by_users.values():
+        if len(u) > 1:
+            # import pdb; pdb.set_trace()
+            combs = itertools.combinations(u, 2)
+            for comb in combs:
+                us1 = comb[0]
+                us2 = comb[1]
+                msg = '{} and {} are the same'.format(
                 us1['display_title'],
                 us2['display_title']
             )
@@ -1273,18 +1286,50 @@ def users_with_doppelganger(connection, **kwargs):
                    'log': 'have the same name',
                    'brief': msg}
             cases.append(log)
-        else:  # this should just provide a warning list that can be periodically reviewed   
-            score = round(string_label_similarity(us1['display_title'], us2['display_title']) * 100)
-            if score > 85:
-                msg = '{} and {} are similar-{}'.format(
-                    us1['display_title'],
-                    us2['display_title'],
-                    str(score))
-                log = {'user1': [us1['display_title'], us1['@id'], us1['email']],
-                       'user2': [us2['display_title'], us2['@id'], us2['email']],
-                       'log': 'has similar names ({}/100)'.format(str(score)),
-                       'brief': msg}
-                iffy_cases.append(log)
+
+
+    # # go through each combination
+    # combs = itertools.combinations(all_users, 2)
+    # cases = []
+    # iffy_cases = []
+    # for comb in combs:
+    #     us1 = comb[0]
+    #     us2 = comb[1]
+    #     # is there a common email between the 2 users
+    #     common_mail = list(set(us1['all_mails']) & set(us2['all_mails']))
+    #     if common_mail:
+    #         msg = '{} and {} share mail(s) {}'.format(
+    #             us1['display_title'],
+    #             us2['display_title'],
+    #             str(common_mail))
+    #         log = {'user1': [us1['display_title'], us1['@id'], us1['email']],
+    #                'user2': [us2['display_title'], us2['@id'], us2['email']],
+    #                'log': 'has shared email(s) {}'.format(str(common_mail)),
+    #                'brief': msg}
+    #         cases.append(log)
+    #     # if not, compare names
+    #     elif us1['display_title'].lower() == us2['display_title'].lower():
+    #         msg = '{} and {} are the same'.format(
+    #             us1['display_title'],
+    #             us2['display_title']
+    #         )
+    #         log = {'user1': [us1['display_title'], us1['@id'], us1['email']],
+    #                'user2': [us2['display_title'], us2['@id'], us2['email']],
+    #                'log': 'have the same name',
+    #                'brief': msg}
+    #         cases.append(log)
+    #     else:  # this should just provide a warning list that can be periodically reviewed   
+    #         score = round(string_label_similarity(us1['display_title'], us2['display_title']) * 100)
+    #         if score > 85:
+    #             msg = '{} and {} are similar-{}'.format(
+    #                 us1['display_title'],
+    #                 us2['display_title'],
+    #                 str(score))
+    #             log = {'user1': [us1['display_title'], us1['@id'], us1['email']],
+    #                    'user2': [us2['display_title'], us2['@id'], us2['email']],
+    #                    'log': 'has similar names ({}/100)'.format(str(score)),
+    #                    'brief': msg}
+    #             iffy_cases.append(log)
 
     # remove ignored cases from all cases
     if ignored_cases:

--- a/chalicelib_fourfront/checks/wrangler_checks.py
+++ b/chalicelib_fourfront/checks/wrangler_checks.py
@@ -1239,25 +1239,26 @@ def users_with_doppelganger(connection, **kwargs):
             an_email = an_email.strip()
             if an_email:
                 query += '&email=' + an_email.strip()
+
+    name_by_users = {}
+    email_by_users = {}
     # get users
     all_users = ff_utils.search_metadata(query, key=connection.ff_keys)
-    # combine all emails for each user
     for a_user in all_users:
+        # combine all emails for each user
         mail_fields = ['email', 'contact_email', 'preferred_email']
         user_mails = []
         for f in mail_fields:
             if a_user.get(f):
                 user_mails.append(a_user[f].lower())
         a_user['all_mails'] = list(set(user_mails))
-    cases = []
-    name_by_users = {}
-    email_by_users = {}
-    for a_user in all_users:
+
         name = a_user.get('display_title').lower()
         name_by_users.setdefault(name, []).append(a_user)
         for email in a_user.get('all_mails', []):
             email_by_users.setdefault(email, []).append(a_user)
 
+    cases = []
     for e, u in email_by_users.items():
         if len(u) > 1:
             combs = itertools.combinations(u, 2)
@@ -1273,10 +1274,9 @@ def users_with_doppelganger(connection, **kwargs):
                    'log': 'has shared email(s) {}'.format(e),
                    'brief': msg}
             cases.append(log)
-            
+
     for u in name_by_users.values():
         if len(u) > 1:
-            # import pdb; pdb.set_trace()
             combs = itertools.combinations(u, 2)
             for comb in combs:
                 us1 = comb[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "4.2.1b1"
+version = "4.2.1.1b1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "4.2.0"
+version = "4.2.1b1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "4.2.1.1b1"
+version = "4.2.1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
This a refactor of the recent refactor of the doppelganger check.

Basically the checks for users with shared emails and case insensitive name equality are now done in an iterative fashion outside of creating all X all combinations of users to catch the most likely doppelganger cases.

The old checking of similar names can now be done optionally - default is False.
This is expensive and may hit the lambda time limit when run on aws but can be run locally if needed.

beta version deployed on foursight-dev