### PR TITLE
Improved handling of user query for higlass items

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ foursight
 Change Log
 ----------
 
+4.4.3
+=====
+* Convert user input str to list in find_expsets_processedfiles_requiring_higlass_items in higlass_checks.py
+
+
 4.4.2
 =====
 * Added 'input_bed' to attr_keys in wfr_utils.py's start_missing_run for ATAC-seq pipeline

--- a/chalicelib_fourfront/checks/higlass_checks.py
+++ b/chalicelib_fourfront/checks/higlass_checks.py
@@ -361,6 +361,9 @@ def find_files_requiring_higlass_items(connection, check_name, action_name, sear
         check.allow_action = False
         return check
 
+    elif search_queries.__class__ != list:
+        search_queries = [search_queries]
+
     # Add the fields we want to return.
     fields_to_include = '&field=' + '&field='.join((
         'accession',

--- a/chalicelib_fourfront/checks/higlass_checks.py
+++ b/chalicelib_fourfront/checks/higlass_checks.py
@@ -834,6 +834,9 @@ def find_expsets_processedfiles_requiring_higlass_items(connection, check_name, 
         check.allow_action = False
         return check
 
+    elif search_queries.__class__ != list:
+        search_queries = [search_queries]
+
     expsets_by_accession = {}
     # Use all of the search queries to make a list of the ExpSets we will work on.
     for query in search_queries:

--- a/chalicelib_fourfront/checks/higlass_checks.py
+++ b/chalicelib_fourfront/checks/higlass_checks.py
@@ -2291,13 +2291,12 @@ def verify_queries(check, search_queries, ignore_queries):
         check.summary = check.description = "No search query provided, nothing to update."
         check.status = 'PASS'
         check.allow_action = False
-        return check
 
     if isinstance(search_queries, str):
         # for case where (possibly multiple) query is passed in via kwargs
         queries = search_queries.split(',')
         search_queries = [q.strip() for q in queries]
-        check.full_output = {
-            "query_error": "The query was not formatted as a list, please double check results"
+        check.brief_output = {
+            "corrected_query": "The query was not formatted as a list, please double check results"
         }
-        return check, search_queries
+    return check, search_queries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "4.4.2"
+version = "4.4.3"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Add helper for three functions used by foursight checks querying for higlass items: `find_expsets_processed`, `files_requiring_higlass_item`, and
`find_expsets_otherprocessedfiles_requiring_higlass_items`. Queries formatted as strings will be corrected to lists (using input commas to split strings as necessary). A warning will be added to `check.brief_output` in this case.