### PR TITLE
Fix for ChIP-seq ctl output assembly patching

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Change Log
 
 4.4.5
 =====
-* Replace outdated file name for ChIP-seq ctl output bed in workflow settings
+* Replace outdated file name for ChIP-seq control output bed in workflow settings
 
 `PR 566: Fix for ChIP-seq ctl output assembly patching <https://github.com/4dn-dcic/foursight/pull/566>`_
 


### PR DESCRIPTION
To be closed, intended to reflect the updates made in https://github.com/4dn-dcic/foursight/commit/8c809e154484129733790b1eab16060e158e6057 (v4.4.5). The change has already been incorporated into master.

Corrects the outdated filename used in wfrset_utils.py to patch output of the control workflow of the ChIP-seq pipeline.