### PR TITLE
remove bam-processing accepted version for reruns

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ foursight
 Change Log
 ----------
 
+4.7.1
+=====
+
+# Modify bam-processing accepted_versions list to enable workflow rerun
+`PR 572: remove bam-processing accepted version for reruns <https://github.com/4dn-dcic/foursight/pull/572>`_
+
 4.7.0
 =====
 

--- a/chalicelib_fourfront/checks/helpers/wfr_utils.py
+++ b/chalicelib_fourfront/checks/helpers/wfr_utils.py
@@ -39,7 +39,7 @@ workflow_details = {
     },
     "hi-c-processing-bam": {
         "run_time": 200,
-        "accepted_versions": ["0.2.6", "0.3.0"]
+        "accepted_versions": ["0.3.0"]
     },
     "hi-c-processing-pairs": {
         "run_time": 200,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "4.7.0"
+version = "4.7.1"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Remove old Hi-C pipeline version from the bam-processing step accepted_versions list.