### PR TITLE
Restrict chromsizes file registration to `higlass_reference`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ foursight
 Change Log
 ----------
 
+4.7.2
+=====
+
+* Exclude chromsizes files that are not `higlass_reference` from registration on the Higlass server.
+
 4.7.1
 =====
 

--- a/chalicelib_fourfront/checks/higlass_checks.py
+++ b/chalicelib_fourfront/checks/higlass_checks.py
@@ -1694,7 +1694,8 @@ def files_not_registered_with_higlass(connection, **kwargs):
             "uuid",
             "extra_files",
             "upload_key",
-            "open_data_url"
+            "open_data_url",
+            "tags"
         ):
             search_query += "&field=" + new_field
 
@@ -1727,7 +1728,8 @@ def files_not_registered_with_higlass(connection, **kwargs):
                 'file_format': procfile['file_format'].get('file_format'),
                 'higlass_uid': procfile.get('higlass_uid'),
                 'genome_assembly': procfile['genome_assembly'],
-                'open_data_url': procfile.get('open_data_url')  # get it if it has it
+                'open_data_url': procfile.get('open_data_url'),  # get it if it has it
+                'tags': procfile.get('tags')
             }
 
             file_format = file_info["file_format"]
@@ -1735,6 +1737,12 @@ def files_not_registered_with_higlass(connection, **kwargs):
             if file_format not in files_to_be_reg:
                 files_to_be_reg[file_format] = []
 
+            # Don't register chromsizes that are not tagged as "higlass_reference". Otherwise
+            # we would register multiple chromsizes files for the same genome assembly. This leads 
+            # to issues in the Higlass genome position search bar.
+            if file_format == "chromsizes" and "higlass_reference" not in file_info["tags"]:
+                continue
+                
             # bg files use an bw file from extra files to register
             # bed files use a beddb or bed.multires.mv5 files from extra files to regiser
             # don't FAIL if the bg is missing the bw, however

--- a/chalicelib_fourfront/checks/higlass_checks.py
+++ b/chalicelib_fourfront/checks/higlass_checks.py
@@ -1729,7 +1729,7 @@ def files_not_registered_with_higlass(connection, **kwargs):
                 'higlass_uid': procfile.get('higlass_uid'),
                 'genome_assembly': procfile['genome_assembly'],
                 'open_data_url': procfile.get('open_data_url'),  # get it if it has it
-                'tags': procfile.get('tags')
+                'tags': procfile.get('tags', [])
             }
 
             file_format = file_info["file_format"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "4.7.1"
+version = "4.7.2"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Exclude chromsizes files that are not `higlass_reference` from registration on the Higlass server.