### PR TITLE
Cleanup and rm rate limit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ foursight
 Change Log
 ----------
 
+4.7.3
+=====
+
+* Change clean_up_webdev_wfrs to run manually and correct test UUIDs
+* fastqc and fastq-first-line checks are no longer rate limited
+* Correct key used for fruit fly reference files and parameters
+`PR 575: cleanup and remove rate limit for select checks <https://github.com/4dn-dcic/foursight/pull/575>`_
+
 4.7.2
 =====
 

--- a/chalicelib_fourfront/check_setup.json
+++ b/chalicelib_fourfront/check_setup.json
@@ -682,7 +682,7 @@
         "title": "Clean up webdev workflows runs",
         "group": "Metadata checks",
         "schedule": {
-            "morning_checks_4": {
+            "manual_checks": {
                 "webdev": {
                     "dependencies": [],
                     "kwargs": {

--- a/chalicelib_fourfront/checks/helpers/wfr_utils.py
+++ b/chalicelib_fourfront/checks/helpers/wfr_utils.py
@@ -227,13 +227,13 @@ feature_calling_accepted_versions = {
 # Reference Files
 bwa_index = {"human": "4DNFIZQZ39L9",
              "mouse": "4DNFI823LSI8",
-             "fruit-fly": '4DNFIO5MGY32',
+             "fruit fly": '4DNFIO5MGY32',
              "chicken": "4DNFIVGRYVQF",
              "zebrafish": "4DNFIUH46PG1"}
 
 chr_size = {"human": "4DNFI823LSII",
             "mouse": "4DNFI3UBJ3HZ",
-            "fruit-fly": '4DNFIBEEN92C',
+            "fruit fly": '4DNFIBEEN92C',
             "chicken": "4DNFIQFZW4DX",
             "zebrafish": "4DNFI5W8CN1M"}
 
@@ -270,7 +270,7 @@ re_nz = {"human": {'MboI': '/files-reference/4DNFI823L812/',
                    "HindIII": '/files-reference/4DNFI6V32T9J/',
                    "Arima - A1, A2": '/files-reference/4DNFIE78H3K7/'
                    },
-         "fruit-fly": {'MboI': '/files-reference/4DNFIS1ZVUWO/'
+         "fruit fly": {'MboI': '/files-reference/4DNFIS1ZVUWO/'
                        },
          "chicken": {"HindIII": '/files-reference/4DNFITPCJFWJ/'
                      },
@@ -289,7 +289,7 @@ re_kmer = {"human": '/files-reference/4DNFIDMVPFSO/',
 # max_distance for species (used for pairsqc)
 max_size = {"human": None,
             "mouse": 8.2,
-            "fruit-fly": 7.5,
+            "fruit fly": 7.5,
             "chicken": 8.2,
             "zebrafish": 7.9}
 
@@ -309,7 +309,7 @@ re_nz_sizes = {"HindIII": "6",
 
 mapper = {'human': 'GRCh38',
           'mouse': 'GRCm38',
-          'fruit-fly': 'dm6',
+          'fruit fly': 'dm6',
           'chicken': 'galGal5',
           'zebrafish': 'GRCz11'}
 

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -363,12 +363,6 @@ def fastqc_status(connection, **kwargs):
     check, skip = wfr_utils.check_indexing(check, connection)
     if skip:
         return check
-    # check number of total workflow runs in the past 6h
-    check, n_runs_available = wfr_utils.limit_number_of_runs(check, my_auth)
-    if n_runs_available == 0:
-        check.brief_output.append('Runs are limited due to docker pull rate limit')
-        check.status = 'WARN'
-        return check
 
     # Build the query (skip to be uploaded by workflow)
     query = ("/search/?type=File&file_format.file_format=fastq&quality_metric.uuid=No+value"
@@ -2143,12 +2137,6 @@ def fastq_first_line_status(connection, **kwargs):
     # check indexing queue
     check, skip = wfr_utils.check_indexing(check, connection)
     if skip:
-        return check
-    # check number of total workflow runs in the past 6h
-    check, n_runs_available = wfr_utils.limit_number_of_runs(check, my_auth)
-    if n_runs_available == 0:
-        check.brief_output.append('Runs are limited due to docker pull rate limit')
-        check.status = 'WARN'
         return check
 
     query = ('/search/?status=uploaded&status=pre-release&status=released+to+project&status=released'

--- a/chalicelib_fourfront/checks/wrangler_checks.py
+++ b/chalicelib_fourfront/checks/wrangler_checks.py
@@ -1005,7 +1005,7 @@ def clean_up_webdev_wfrs(connection, **kwargs):
     wait = round(random.uniform(0.1, random_wait), 1)
     time.sleep(wait)
     # input for test pseudo hi-c-processing-bam
-    response = ff_utils.get_metadata('68f38e45-8c66-41e2-99ab-b0b2fcd20d45',
+    response = ff_utils.get_metadata('1150b428-272b-4a0c-b3e6-4b405c148f7c',
                                      key=connection.ff_keys)
     wfrlist = response['workflow_run_inputs']
     for entry in wfrlist:
@@ -1016,7 +1016,7 @@ def clean_up_webdev_wfrs(connection, **kwargs):
         patch_wfr_and_log(entry, check.full_output)
 
     # input for test md5 and bwa-mem
-    response = ff_utils.get_metadata('f4864029-a8ad-4bb8-93e7-5108f462ccaa',
+    response = ff_utils.get_metadata('1fa2d6db-8a1f-4ba5-aa61-0558f80b0cf7',
                                      key=connection.ff_keys)
     wfrlist = response['workflow_run_inputs']
     for entry in wfrlist:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "4.7.2"
+version = "4.7.3"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Miscellaneous cleanup:
- Change clean_up_webdev_wfrs to run manually and correct test UUIDs
- fastqc and fastq-first-line checks are no longer rate limited
- Correct key used for fruit fly reference files and parameters