### PR TITLE
increase EC2 instance size for select QCs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ foursight
 Change Log
 ----------
 
+4.8.2
+=====
+
+* Increases EC2 utilized by select QC pipelines from t3.small to t3.medium
+`PR 578: increase EC2 instance size for select QCs <https://github.com/4dn-dcic/foursight/pull/578>`_
+
 4.8.1
 =====
 

--- a/chalicelib_fourfront/checks/helpers/wfrset_utils.py
+++ b/chalicelib_fourfront/checks/helpers/wfrset_utils.py
@@ -38,7 +38,7 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
         'workflow_uuid': 'c77a117b-9a58-477e-aaa5-291a109a99f6',
         "config": {
             "ebs_size": 10,
-            "instance_type": 't3.small',
+            "instance_type": 't3.medium',
             'EBS_optimized': True
         }
     },
@@ -47,14 +47,14 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
         'workflow_uuid': '49e96b51-ed6c-4418-a693-d0e9f79adfa5',
         "config": {
             "ebs_size": 10,
-            "instance_type": 't3.small',
+            "instance_type": 't3.medium',
             'EBS_optimized': True
         }
     },
     {
         'app_name': 'pairsqc-single',
         'workflow_uuid': 'b8c533e0-f8c0-4510-b4a1-ac35158e27c3',
-        "config": {"instance_type": 't3.small'}
+        "config": {"instance_type": 't3.medium'}
     },
     {
         'app_name': 'bwa-mem',
@@ -404,7 +404,7 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
         "app_name": "fastq-first-line",
         "workflow_uuid": "93a1a931-d55d-4623-adfb-0fa735daf6ae",
         "overwrite_input_extra": False,
-        'config': {'mem': 2, 'cpu': 2, "instance_type": "t3.small"}
+        'config': {'mem': 2, 'cpu': 2, "instance_type": "t3.medium"}
     },
     {
         "app_name": "re_checker_workflow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "4.8.1"
+version = "4.8.2"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
For md5, fastq-first-line, fastqc, and pairsqc, step settings specify a t3.medium rather than t3.small