### PR TITLE
Remove rate limit for md5_status check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ foursight
 Change Log
 ----------
 
+4.9.7
+=====
+
+`PR 585: Remove rate limit for md5_status check <https://github.com/4dn-dcic/foursight/pull/585>`_
+
+* remove rate limiting (and related variables) for md5_status check
+
+
 4.9.6
 =====
 * 2024-10-11/dmichaels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "4.9.6"
+version = "4.9.7"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Remove rate limiting (and related variables) for md5_status check.

No md5-related checks should use rate limiting after this change.