### PR TITLE
Ignore non-mcools in insulation-score check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change Log
 `PR 586: Ignore non-mcools in insulation-score check <https://github.com/4dn-dcic/foursight/pull/586>`_
 
 * The insulation score and boundaries caller check won't append a file to its output unless it is the mcool
+* Add pre-released files to mcoolQC query
 
 4.9.7
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ foursight
 Change Log
 ----------
 
+4.9.8
+=====
+
+`PR 586: Ignore non-mcools in insulation-score check <https://github.com/4dn-dcic/foursight/pull/586>`_
+
+* The insulation score and boundaries caller check won't append a file to its output unless it is the mcool
+
 4.9.7
 =====
 

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -2835,7 +2835,7 @@ def mcoolqc_status(connection, **kwargs):
     if skip:
         return check
     # Build the query (find mcool files)
-    default_stati = 'released&status=uploaded&status=released+to+project'
+    default_stati = 'released&status=uploaded&status=released+to+project&status=pre-release'
     stati = 'status=' + (kwargs.get('status') or default_stati)
     query = 'search/?file_format.file_format=mcool&{}'.format(stati)
     query += '&type=FileProcessed'

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -2347,6 +2347,13 @@ def insulation_scores_and_boundaries_status(connection, **kwargs):
                 file_meta = ff_utils.get_metadata(pfile['accession'], key=my_auth)
                 qc_values = file_meta['quality_metric']['quality_metric_summary'][0]['value']
                 problematic_resolutions = qc_values.split('; ')
+                
+                # Skip tagged mcools files as needed
+                if file_meta.get('tags'):
+                    if 'skip_domain_callers' in file_meta['tags']:
+                        skip = True
+                        continue
+                
                 # verify if binsize is good
                 enz = a_res['experiments_in_set'][0]['digestion_enzyme']['name']
                 organism = a_res['experiments_in_set'][0]['biosample']['biosource'][0]['organism']['name']
@@ -2365,11 +2372,6 @@ def insulation_scores_and_boundaries_status(connection, **kwargs):
                 if str(binsize) in problematic_resolutions:
                     skip = True
                     continue
-                # Skip tagged mcools files as needed
-                if file_meta.get('tags'):
-                    if 'skip_domain_callers' in file_meta['tags']:
-                        skip = True
-                        continue
                 insu_and_boun_report = wfr_utils.get_wfr_out(file_meta, "insulation-scores-and-boundaries-caller", key=my_auth, **kwargs)
             
                 # only want to modify report if we're looking at an mcool file

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -2375,9 +2375,7 @@ def insulation_scores_and_boundaries_status(connection, **kwargs):
                 insu_and_boun_report = wfr_utils.get_wfr_out(file_meta, "insulation-scores-and-boundaries-caller", key=my_auth, **kwargs)
             
                 # only want to modify report if we're looking at an mcool file
-                if skip:
-                    continue
-                elif insu_and_boun_report['status'] == 'running':
+                if insu_and_boun_report['status'] == 'running':
                     running.append(pfile['accession'])
                 elif insu_and_boun_report['status'].startswith("no complete run, too many"):
                     problematic_run.append(['step1', a_res['accession'], pfile['accession']])

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -2371,21 +2371,23 @@ def insulation_scores_and_boundaries_status(connection, **kwargs):
                         skip = True
                         continue
                 insu_and_boun_report = wfr_utils.get_wfr_out(file_meta, "insulation-scores-and-boundaries-caller", key=my_auth, **kwargs)
-        if skip:
-            continue
-        elif insu_and_boun_report['status'] == 'running':
-            running.append(pfile['accession'])
-        elif insu_and_boun_report['status'].startswith("no complete run, too many"):
-            problematic_run.append(['step1', a_res['accession'], pfile['accession']])
-        elif insu_and_boun_report['status'] != 'complete':
-            overwrite = {'parameters': {"binsize": binsize}}
-            inp_f = {'mcoolfile': pfile['accession']}
-            missing_run.append(['step1', ['insulation-scores-and-boundaries-caller', organism, overwrite],
-                                inp_f, a_res['accession']])
-        else:
-            patch_data = [insu_and_boun_report['bedfile'], insu_and_boun_report['bwfile']]
-            completed['patch_opf'].append([a_res['accession'], patch_data])
-            completed['add_tag'] = [a_res['accession'], wfr_utils.feature_calling_accepted_versions[feature][-1]]
+            
+                # only want to modify report if we're looking at an mcool file
+                if skip:
+                    continue
+                elif insu_and_boun_report['status'] == 'running':
+                    running.append(pfile['accession'])
+                elif insu_and_boun_report['status'].startswith("no complete run, too many"):
+                    problematic_run.append(['step1', a_res['accession'], pfile['accession']])
+                elif insu_and_boun_report['status'] != 'complete':
+                    overwrite = {'parameters': {"binsize": binsize}}
+                    inp_f = {'mcoolfile': pfile['accession']}
+                    missing_run.append(['step1', ['insulation-scores-and-boundaries-caller', organism, overwrite],
+                                        inp_f, a_res['accession']])
+                else:
+                    patch_data = [insu_and_boun_report['bedfile'], insu_and_boun_report['bwfile']]
+                    completed['patch_opf'].append([a_res['accession'], patch_data])
+                    completed['add_tag'] = [a_res['accession'], wfr_utils.feature_calling_accepted_versions[feature][-1]]
 
         if running:
             check.full_output['running_runs'].append({a_res['accession']: running})

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -2403,7 +2403,7 @@ def insulation_scores_and_boundaries_status(connection, **kwargs):
         check.summary = str(len(check.full_output['running_runs'])) + ' running|'
     if check.full_output['needs_runs']:
         check.summary += str(len(check.full_output['needs_runs'])) + ' missing|'
-        check.allow_action = True
+        check.allow_action = False
         check.status = 'WARN'
     if check.full_output['completed_runs']:
         check.summary += str(len(check.full_output['completed_runs'])) + ' completed|'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "4.9.7"
+version = "4.9.8"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
The insulation-score calling pipeline should ignore processed files which are not mcools so as to avoid starting runs with the incorrect input file (and therefore avoiding starting runs after failing more than twice).