### PR TITLE
Remove restricted status from 2 checks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,16 @@ foursight
 Change Log
 ----------
 
+4.9.9
+=====
+
+`PR ???: Remove restricted status from search query <https://github.com/4dn-dcic/foursight/pull/???>`_
+
+* Remove the 'restricted' status from the search query in the fastq_first_line check
+* Remove the 'restricted' status from the search query in the bamQC check (and add pre-release)
+* will allow files that have not been uploaded to be set to 'restricted' status and not trigger runs of these checks
+
+
 4.9.8
 =====
 

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -1977,7 +1977,7 @@ def bamqc_status(connection, **kwargs):
     if skip:
         return check
     # Build the query
-    default_stati = 'released&status=uploaded&status=released+to+project&status=restricted'
+    default_stati = 'released&status=uploaded&status=released+to+project&status=pre-release'
     # find bam files produced bt the Hi-C Post Alignment Processing wfr
     wfr_outputs = "&workflow_run_outputs.workflow.title=Hi-C+Post-alignment+Processing+0.2.6"
     stati = 'status=' + (kwargs.get('status') or default_stati)
@@ -2069,7 +2069,7 @@ def fastq_first_line_status(connection, **kwargs):
         return check
 
     query = ('/search/?status=uploaded&status=pre-release&status=released+to+project&status=released'
-             '&type=FileFastq&file_format.file_format=fastq&file_first_line=No value&status=restricted')
+             '&type=FileFastq&file_format.file_format=fastq&file_first_line=No value')
 
     # The search
     print('About to query ES for files')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "4.9.8"
+version = "4.9.9"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
In order to prevent triggering fastq_firstline or bamQC runs on 'restricted' files that have not been uploaded and therefore will fail the runs the searches in those checks have been modified to remove files with 'restricted' status from the results.