### PR TITLE
Deduplicate control TAs in ChIP-seq input JSON

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Change Log
 4.9.10
 =====
 
-`PR`_
+`PR 588: Deduplicate control TAs in ChIP-seq input JSON <https://github.com/4dn-dcic/foursight/pull/588>`_
 
 * For ChIP-seq sets with 2+ identical control TA files, replace multi-file ctl list with one-item list
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ foursight
 Change Log
 ----------
 
+4.9.10
+=====
+
+`PR`_
+
+* For ChIP-seq sets with 2+ identical control TA files, replace multi-file ctl list with one-item list
+
+
 4.9.9
 =====
 

--- a/chalicelib_fourfront/checks/wfr_encode_checks.py
+++ b/chalicelib_fourfront/checks/wfr_encode_checks.py
@@ -388,6 +388,10 @@ def chipseq_status(connection, **kwargs):
                 if ta_cnt:
                     s2_input_files['chip.ctl_tas'] = ta_cnt
                     s2_input_files['additional_file_parameters']['chip.ctl_tas'] = {"rename": rename_chip(ta_cnt)}
+                    if len(set(ta_cnt)) == 1 and len(ta_cnt) != 1:
+                        print("Control TAs are identical, listing file only once")
+                        s2_input_files['chip.ctl_tas'] = [ta_cnt[0]]
+                        s2_input_files['additional_file_parameters']['chip.ctl_tas'] = {"rename": rename_chip([ta_cnt[0]])}
 
                 # collect parameters
                 parameters = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "4.9.9"
+version = "4.9.10"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
For ChIP-seq sets with 2+ identical control tagAlign files, replace multi-file control list with a one-item list.

For example:
`s2_input_files['chip.ctl_tas'] = ['fileA', 'fileA', 'fileA']` will be replaced with `s2_input_files['chip.ctl_tas'] = ['fileA']`

Files are also renamed accordingly. No changes made in the case that some but not all control files are identical.