### PR TITLE
update config for RNA-seq runs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Change Log
 
 `PR 592: bug fixes <https://github.com/4dn-dcic/foursight/pull/592>`_
 
-* Adjust RNA-seq workflows to rely on benchmarking and insulation-score caller to avoid micro instance
+* Adjust RNA-seq workflows to rely on benchmarking and adjust mergebed to avoid micro instances
 
 
 4.9.16

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ foursight
 Change Log
 ----------
 
+4.9.17
+======
+
+`PR 592: bug fixes <https://github.com/4dn-dcic/foursight/pull/592>`_
+
+* Adjust RNA-seq workflows to rely on benchmarking and insulation-score caller to avoid micro instance
+
+
 4.9.16
 ======
 

--- a/chalicelib_fourfront/checks/helpers/wfrset_utils.py
+++ b/chalicelib_fourfront/checks/helpers/wfrset_utils.py
@@ -233,7 +233,7 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
         "app_name": "encode-chipseq-postaln",
         "workflow_uuid": "291d4c64-75de-434a-9d98-01f40d19e15e",
         "parameters": {},
-        "config": {"instance_type": "c5.2xlarge", "ebs_size": 80},
+        "config": {"instance_type": "c5.2xlarge", "ebs_size": 120},
         'custom_pf_fields': {
             'chip.optimal_peak': {
                 'genome_assembly': genome,
@@ -285,6 +285,7 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
         "app_name": "mergebed",
         "workflow_uuid": "2b10e472-065e-43ed-992c-fccad6417b65",
         "parameters": {"sortv": "0"},
+        "config": {"mem": 2, "cpu": 2},
         'custom_pf_fields': {
             'merged_bed': {
                 'genome_assembly': genome,
@@ -334,7 +335,7 @@ def step_settings(step_name, my_organism, attribution, overwrite=None):
             'rna.strandedness_direction': '',
             'rna.endedness': ''
         },
-        "config": {"instance_type": ["m5a.4xlarge", "m6a.4xlarge"], "ebs_size": 90},
+        "config": {"instance_type": ["m5a.4xlarge", "m6a.4xlarge"]},
         'custom_pf_fields': {
             'rna.outbam': {
                 'genome_assembly': genome,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "4.9.16"
+version = "4.9.17"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
- Update stranded runs of RNA-seq to rely on benchmarking rather than hardcoded disk configuration. The unstranded version of this workflow does this by default.
- Update mergebed to avoid pulling a micro instance
- Increase default disk space for ChIP-seq postaln workflow runs (based on past run utilization metrics)