### PR TITLE
Ajs 250630 rawfile badge ignore restricted

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ foursight
 Change Log
 ----------
 
+4.9.27
+==========
+* modify missing raw file check to not add badge if files are restricted and missing as this is expected in some cases
+
 4.9.26
 ==========
 * only a version bump to allow tagging via tag-and-push and make release history clear in pypi

--- a/chalicelib_fourfront/checks/badge_checks.py
+++ b/chalicelib_fourfront/checks/badge_checks.py
@@ -474,7 +474,11 @@ def exp_has_raw_files(connection, **kwargs):
     bad_status_ids = {item['@id']: item['status'] for item in bad_status}
     exps = list(set([exp['@id'] for fastq in bad_status for exp in
                      fastq.get('experiments') if fastq.get('experiments')]))
-    missing_files_released = [e['@id'] for e in no_files]
+    ok_status = ff_utils.search_metadata('search/?status=restricted&type=FileFastq&experiments.uuid%21=No+value',
+                                          key=connection.ff_keys)
+    ok_exps = list(set([exp['@id'] for fastq in ok_status for exp in
+                        fastq.get('experiments') if fastq.get('experiments')]))
+    missing_files_released = [e['@id'] for e in no_files if e['@id'] not in ok_exps]
     for expt in exps:
         result = ff_utils.get_metadata(expt, key=connection.ff_keys)
         raw_files = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "4.9.26"
+version = "4.9.27"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
If we don't have a 4DN pipeline to run on a dataset and the data is protected (i.e. from not fully consented human donors) then there is no reason to have the fastq files uploaded.

The check for missing raw files on sequencing experiments has been updated to exclude these types of sets from being flagged for badge addition.