### PR TITLE
Ajs 250731 fix not uploaded bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ foursight
 Change Log
 ----------
 
+4.9.29
+==========
+* bug. fix for some pre-release files being missed that need md5 runs
+
+
 4.9.28
 ==========
 * update fastq checks to not run pipelines on pre-release status files that have not been uploaded as OK as they will become restricted

--- a/chalicelib_fourfront/checks/helpers/wfr_utils.py
+++ b/chalicelib_fourfront/checks/helpers/wfr_utils.py
@@ -2084,7 +2084,10 @@ def prereleased_and_not_uploaded(connection, filemeta):
     if filemeta.get('status') not in statuses_to_check:
         return False
     my_s3_util = s3Utils(env=connection.ff_env)
-    if not my_s3_util.does_key_exist(filemeta.get('upload_key'), my_s3_util.raw_file_bucket, False):
-        # if the file is not in the raw bucket, it is not uploaded
+    bucket = my_s3_util.raw_file_bucket
+    if 'FileProcessed' in filemeta.get('@type', []):
+        bucket = my_s3_util.outfile_bucket
+    if not my_s3_util.does_key_exist(filemeta.get('upload_key'), bucket, False):
+        # if the file is not in the bucket, it is not uploaded
         return True
     return False

--- a/chalicelib_fourfront/checks/wfr_checks.py
+++ b/chalicelib_fourfront/checks/wfr_checks.py
@@ -264,9 +264,9 @@ def md5run_uploaded_files(connection, **kwargs):
                 has_md5run = True
                 break
         if has_md5run:
-            files.setdefault('files_with_md5run', []).append(f['accession'])
+            files.setdefault('uploaded_with_md5run', []).append(f['accession'])
         else:
-            files.setdefault('files_without_md5run', []).append(f['accession'])
+            files.setdefault('uploaded_without_md5run', []).append(f['accession'])
 
     if files.get('uploaded_without_md5run') or files.get('uploaded_with_md5run'):
         check.status = 'WARN'
@@ -274,9 +274,9 @@ def md5run_uploaded_files(connection, **kwargs):
         check.description = 'Some files with status updloaded or higher are missing md5sum'
         check.brief_output = {k: str(len(v)) + ' files' for k, v in files.items()}
         check.full_output = files
-        if files['uploaded_without_md5run']:
+        if files.get('uploaded_without_md5run'):
             check.allow_action = True
-        if files['uploaded_with_md5run']:
+        if files.get('uploaded_with_md5run'):
             check.action_message = ('Action will only run on Files without previous md5 run. ' +
                                     'You need to manually fix those with previous md5 run.')
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foursight"
-version = "4.9.28"
+version = "4.9.29"
 description = "Serverless Chalice Application for Monitoring"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Fix for a bug that was introduced in the check for uploaded files that lacked an md5 runs.  
2 changes:
- deal properly with processed files
- rename the keys for storing the problematic files as they were mismatched