### PR TITLE
migrate all workflows to OIDC auth

### DIFF
--- a/.github/workflows/main-CI.yml
+++ b/.github/workflows/main-CI.yml
@@ -13,6 +13,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -32,12 +35,13 @@ jobs:
         run: make build
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
+      - name: Verify AWS Identity
+        run: aws sts get-caller-identity
       - name: CI
         env:
           S3_ENCRYPT_KEY: ${{ secrets.S3_ENCRYPT_KEY }}

--- a/.github/workflows/main-CI.yml
+++ b/.github/workflows/main-CI.yml
@@ -40,8 +40,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
-      - name: Verify AWS Identity
-        run: aws sts get-caller-identity
       - name: CI
         env:
           S3_ENCRYPT_KEY: ${{ secrets.S3_ENCRYPT_KEY }}

--- a/.github/workflows/main-deploy-dev.yml
+++ b/.github/workflows/main-deploy-dev.yml
@@ -7,6 +7,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read    
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -26,12 +29,13 @@ jobs:
         run: make build
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
+      - name: Verify AWS Identity
+        run: aws sts get-caller-identity
       - name: Deploy
         env:
           DEV_SECRET: ${{ secrets.DEV_SECRET }}

--- a/.github/workflows/main-deploy-dev.yml
+++ b/.github/workflows/main-deploy-dev.yml
@@ -34,8 +34,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
-      - name: Verify AWS Identity
-        run: aws sts get-caller-identity
       - name: Deploy
         env:
           DEV_SECRET: ${{ secrets.DEV_SECRET }}

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -7,6 +7,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -24,13 +28,14 @@ jobs:
 
       - name: Build
         run: make build
-
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
+
+      - name: Verify AWS Identity
+        run: aws sts get-caller-identity
 
       - name: Deploy
         env:

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -34,8 +34,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
-      - name: Verify AWS Identity
-        run: aws sts get-caller-identity
 
       - name: Deploy
         env:


### PR DESCRIPTION
Replaces static AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY GitHub secrets 
with OIDC role assumption across all three workflows. This is more secure 
as it eliminates long-lived AWS credentials stored as GitHub secrets.

## Changes
- `main-CI.yml` — switched to OIDC auth
- `main-deploy-dev.yml` — switched to OIDC auth  
- `main-deploy.yml` — switched to OIDC auth
- All three: bumped `configure-aws-credentials` v1 → v4 (required for OIDC)
- All three: added `permissions: id-token: write` block (required for GitHub to issue OIDC token)

## Testing
- ✅ CI passed on this branch (minus a pre-existing Elasticsearch ConnectTimeout 
     unrelated to this change)
- ✅ AWS credentials step passes with OIDC role assumption confirmed
- ✅ deploy-dev run manually from this branch

## After this is merged
The following repo secrets can be deleted by an admin if this key is not used anywhere else within the repository:
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`

`AWS_OIDC_ROLE_ARN` must remain.

## NOTES
The Elasticsearch ConnectTimeout seen in CI is a pre-existing issue unrelated 
to this change. Ran into AccessDenied issues which I fixed via the IAM Role Permissions but this ConnectTimeout should be unrelated and investigated separately.